### PR TITLE
Add support for wolfCrypt AES CMAC

### DIFF
--- a/cipher/mac-internal.h
+++ b/cipher/mac-internal.h
@@ -25,6 +25,7 @@
 
 #ifdef HAVE_WOLFSSL
 #include "wolfssl/wolfcrypt/hmac.h"
+#include "wolfssl/wolfcrypt/cmac.h"
 #include "wolfssl/wolfcrypt/aes.h"
 #endif
 
@@ -120,7 +121,9 @@ struct gcry_mac_handle
   size_t authIn_len;
   byte* authTag;
   size_t authTag_len;
+  int authTagUpdated;
   Gmac aesGmac;
+  Cmac aesCmac;
 #endif
   union {
     struct {


### PR DESCRIPTION
This allows the user to use the wolfCrypt implementation of AES CMAC instead of the underlying CMAC implementation in libgcrypt when built with HAVE_WOLFSSL defined