### PR TITLE
Implement wolfCrypt AES GCM support

### DIFF
--- a/cipher/cipher-ccm.c
+++ b/cipher/cipher-ccm.c
@@ -686,6 +686,7 @@ _wc_cipher_aes_ccm_encrypt (gcry_cipher_hd_t c, unsigned char *outbuf,
   if (ret != 0)
     return GPG_ERR_INV_ARG;
 
+  wc_c->cryptbuf_len += inbuflen;
   c->u_mode.ccm.encryptlen -= inbuflen;
   memcpy(outbuf, &wc_c->cryptbuf[newdatastart], inbuflen);
   return GPG_ERR_NO_ERROR;

--- a/cipher/cipher-gcm.c
+++ b/cipher/cipher-gcm.c
@@ -29,8 +29,6 @@
 #include "bufhelp.h"
 #include "./cipher-internal.h"
 
-#undef HAVE_WOLFSSL
-
 #ifdef HAVE_WOLFSSL
 #include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/settings.h>
@@ -1278,351 +1276,427 @@ _gcry_cipher_gcm_check_tag (gcry_cipher_hd_t c, const unsigned char *intag,
 /* WolfSSL AES GCM Encryption */
 #ifdef HAVE_WOLFSSL
 
-/* Function will init the aes context and set the key, iv */
-/* Will not reinitialize the context if it is already initialized */
-void _wc_init_aes_gcm(gcry_cipher_hd_t c)
+#include "rijndael-internal.h"
+
+static gcry_err_code_t
+_wc_realloc_if_needed(wc_gcm_context_t *wc_c,
+                      size_t outbuflen, size_t inbuflen)
 {
-  int ret;
-  Aes* enc = &c->u_mode.gcm.wc_aes_gcm_enc;
-  Aes* dec = &c->u_mode.gcm.wc_aes_gcm_dec;
-
-  /* Make sure we have the key (using the correct location) */
-  byte* key = c->u_mode.gcm.key;
-  size_t keylen = c->u_mode.gcm.keySz;
-
-  /* IV handling */
-  byte* iv = c->u_mode.gcm.iv;
-  size_t ivlen = c->u_mode.gcm.ivSz;
-
-  /* AAD data */
-  byte* authIn = c->u_mode.gcm.authIn;
-  size_t authInSz = c->u_mode.gcm.authInSz;
-
-  /* Ensure we have an IV */
-  if (iv == NULL) {
-    /* allocate iv */
-    iv = (byte*)malloc(12);
-    if (iv == NULL) {
-      printf("Failed to allocate memory for iv\n");
-      return;
-    }
-    /* Set to Zero */
-    memset(iv, 0, 12);
-    ivlen = 12;
-
-    /* Update the context */
-    c->u_mode.gcm.iv = iv;
-    c->u_mode.gcm.ivSz = ivlen;
+  if (wc_c->databuf == NULL) {
+    size_t databufcap = (256 < inbuflen) ? inbuflen : 256;
+    wc_c->databuf = calloc(databufcap, sizeof *wc_c->databuf);
+    if (wc_c->databuf == NULL)
+      return GPG_ERR_ENOMEM;
+    wc_c->databuf_cap = databufcap;
   }
 
-  if (authIn == NULL) {
-    c->u_mode.gcm.authInSz = 0;
+  if (wc_c->cryptbuf == NULL) {
+    size_t cryptbufcap = (256 < inbuflen) ? inbuflen : 256;
+    wc_c->cryptbuf = calloc(cryptbufcap, sizeof *wc_c->cryptbuf);
+    if (wc_c->cryptbuf == NULL)
+      return GPG_ERR_ENOMEM;
+    wc_c->cryptbuf_cap = cryptbufcap;
   }
 
-  /* If the context is not initialized, we need to initialize it */
-  if (c->u_mode.gcm.wcAesGcmInit == 0) {
-    /* Setup the authTag to zero */
-    memset(c->u_mode.gcm.authTag, 0, 16);
-
-    /* Verify we have a key */
-    if (key == NULL || keylen == 0) {
-      printf("Key not set or has zero length\n");
-      return;
-    }
-
-    /* Initialize decrypt context */
-    wc_AesFree(dec);
-    ret = wc_AesInit(dec, NULL, INVALID_DEVID);
-    if (ret != 0) {
-      printf("wc_AesInit failed for decrypt: %d\n", ret);
-      return;
-    }
-
-    ret = wc_AesGcmDecryptInit(dec, key, keylen, iv, ivlen);
-    if (ret != 0) {
-      printf("wc_AesGcmDecryptInit failed: %d\n", ret);
-      return;
-    }
-
-    /* Initialize encrypt context */
-    wc_AesFree(enc);
-    ret = wc_AesInit(enc, NULL, INVALID_DEVID);
-    if (ret != 0) {
-      printf("wc_AesInit failed for encrypt: %d\n", ret);
-      return;
-    }
-
-    ret = wc_AesGcmEncryptInit(enc, key, keylen, iv, ivlen);
-    if (ret != 0) {
-      printf("wc_AesGcmEncryptInit failed: %d\n", ret);
-      return;
-    }
-
-    c->u_mode.gcm.wcAesGcmInit = 1;
-    c->u_mode.gcm.wcAesEncrypt = 0;
-    c->u_mode.gcm.wcAesDecrypt = 0;
+  if (wc_c->databuf_len + inbuflen > wc_c->databuf_cap) {
+    size_t defaultcap = wc_c->databuf_cap + 256;
+    size_t inbufcap = wc_c->databuf_cap + inbuflen;
+    size_t databufcap = defaultcap > inbufcap ? defaultcap : inbufcap;
+    wc_c->databuf = realloc(wc_c->databuf, databufcap);
+    if (wc_c->databuf == NULL)
+      return GPG_ERR_ENOMEM;
+    wc_c->databuf_cap = databufcap;
   }
 
-  return;
+  if (wc_c->cryptbuf_len + inbuflen > wc_c->cryptbuf_cap) {
+    size_t defaultcap = wc_c->cryptbuf_cap + 256;
+    size_t inbufcap = wc_c->cryptbuf_cap + inbuflen;
+    size_t cryptbufcap = defaultcap > inbufcap ? defaultcap : inbufcap;
+    wc_c->cryptbuf = realloc(wc_c->cryptbuf, cryptbufcap);
+    if (wc_c->cryptbuf == NULL)
+      return GPG_ERR_ENOMEM;
+    wc_c->cryptbuf_cap = cryptbufcap;
+  }
+
+  return GPG_ERR_NO_ERROR;
 }
 
+gcry_err_code_t
+_wc_cipher_aes_gcm_close(gcry_cipher_hd_t c)
+{
+  Aes *aesGcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
+  Aes *aesGcmDec = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_dec);
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
 
-void
+  if (wc_c->iv) {
+    free(wc_c->iv);
+    wc_c->iv = NULL;
+    wc_c->iv_len = 0;
+  }
+
+  if (wc_c->databuf) {
+    free(wc_c->databuf);
+    wc_c->databuf = NULL;
+    wc_c->databuf_len = 0;
+    wc_c->databuf_cap = 0;
+  }
+
+  if (wc_c->cryptbuf) {
+    free(wc_c->cryptbuf);
+    wc_c->cryptbuf = NULL;
+    wc_c->cryptbuf_len = 0;
+    wc_c->cryptbuf_cap = 0;
+  }
+
+  if (wc_c->aadbuf) {
+    free(wc_c->aadbuf);
+    wc_c->aadbuf = NULL;
+    wc_c->aadbuf_len = 0;
+  }
+  wc_AesFree(aesGcmEnc);
+  wc_AesFree(aesGcmDec);
+
+  return GPG_ERR_NO_ERROR;
+}
+
+gcry_err_code_t
 _wc_cipher_aes_gcm_reset(gcry_cipher_hd_t c)
 {
-  /* Free IV if not NULL */
-  if (c->u_mode.gcm.iv != NULL) {
-    memset(c->u_mode.gcm.iv, 0, c->u_mode.gcm.ivSz);
-    free(c->u_mode.gcm.iv);
-    c->u_mode.gcm.iv = NULL;
-    c->u_mode.gcm.ivSz = 0;
+  Aes *aesGcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
+  unsigned int marks_key, marks_allow_weak_key;
+  byte key[aesGcmEnc->keylen];
+  size_t keylen = aesGcmEnc->keylen;
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
+
+  if (wc_c->iv) {
+    free(wc_c->iv);
+    wc_c->iv = NULL;
+    wc_c->iv_len = 0;
   }
 
-  /* Clear the authTag by setting to zero */
-  memset(c->u_mode.gcm.authTag, 0, 16);
-
-  /* Free the authIn if not NULL */
-  if (c->u_mode.gcm.authIn != NULL) {
-    memset(c->u_mode.gcm.authIn, 0, c->u_mode.gcm.authInSz);
-    free(c->u_mode.gcm.authIn);
-    c->u_mode.gcm.authIn = NULL;
-    c->u_mode.gcm.authInSz = 0;
+  if (wc_c->databuf) {
+    free(wc_c->databuf);
+    wc_c->databuf = NULL;
+    wc_c->databuf_len = 0;
+    wc_c->databuf_cap = 0;
   }
 
-  /* Set to not initialized */
-  c->marks.finalize = 0;
-  c->u_mode.gcm.wcAesGcmInit = 0;
+  if (wc_c->cryptbuf) {
+    free(wc_c->cryptbuf);
+    wc_c->cryptbuf = NULL;
+    wc_c->cryptbuf_len = 0;
+    wc_c->cryptbuf_cap = 0;
+  }
 
-  /* Reinitialize */
-  _wc_init_aes_gcm(c);
+  if (wc_c->aadbuf) {
+    free(wc_c->aadbuf);
+    wc_c->aadbuf = NULL;
+    wc_c->aadbuf_len = 0;
+  }
 
-  return;
+  wc_gcm_context_t save_wc_c = c->u_mode.gcm.wc_gcm;
+
+  memcpy(key, aesGcmEnc->key, keylen);
+  marks_key = c->marks.key;
+  marks_allow_weak_key = c->marks.allow_weak_key;
+
+  memset (&c->marks, 0, sizeof c->marks);
+  memset (&c->u_mode.gcm, 0, sizeof c->u_mode.gcm);
+  memset (c->u_iv.iv, 0, c->spec->blocksize);
+  memset (c->lastiv, 0, c->spec->blocksize);
+  memset (c->u_ctr.ctr, 0, c->spec->blocksize);
+  c->unused = 0;
+
+  memcpy(wc_c, &save_wc_c, sizeof *wc_c);
+
+  c->marks.key = marks_key;
+  c->marks.allow_weak_key = marks_allow_weak_key;
+
+  return GPG_ERR_NO_ERROR;
 }
 
 gcry_err_code_t
-_wc_cipher_aes_gcm_encrypt (gcry_cipher_hd_t c,
-                   unsigned char *outbuf, size_t outbuflen,
-                   const unsigned char *inbuf, size_t inbuflen)
+_wc_cipher_aes_gcm_setkey(gcry_cipher_hd_t c, const byte *key, size_t keylen)
 {
-  //prinft*"wc_cipher_aes_gcm_encrypt*******\n");
-  int ret = 0;
-  Aes* enc = &c->u_mode.gcm.wc_aes_gcm_enc;
-  byte* authIn = c->u_mode.gcm.authIn;
-  size_t authInSz = c->u_mode.gcm.authInSz;
+  int ret;
+  Aes *aesGcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
+  Aes *aesGcmDec = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_dec);
 
-  _wc_init_aes_gcm(c);
+  if (key == NULL || keylen == 0 || keylen > 32)
+    return GPG_ERR_INV_ARG;
 
-  /* Check all parameters before calling wc_AesGcmEncrypt */
-  ret = wc_AesGcmEncryptUpdate(enc, outbuf, inbuf, inbuflen, NULL, 0);
-  if (ret != 0) {
-    printf("wc_AesGcmEncrypt failed: %d\n", ret);
-    return;
-  }
-  /* To tell last operation was encrypt */
-  c->u_mode.gcm.wcAesEncrypt = 1;
-  c->u_mode.gcm.wcAesDecrypt = 0;
-  return ret;
+  ret = wc_AesGcmSetKey(aesGcmEnc, key, keylen);
+  if (ret != 0)
+    return GPG_ERR_INV_ARG;
+
+  ret = wc_AesGcmSetKey(aesGcmDec, key, keylen);
+  if (ret != 0)
+    return GPG_ERR_INV_ARG;
+
+  return GPG_ERR_NO_ERROR;
 }
-
-
-/* WolfSSL AES GCM Decryption */
-gcry_err_code_t
-_wc_cipher_aes_gcm_decrypt (gcry_cipher_hd_t c,
-                   unsigned char *outbuf, size_t outbuflen,
-                   const unsigned char *inbuf, size_t inbuflen)
-{
-  /* Check if the context is initialized */
-  int ret = 0;
-  Aes* dec = &c->u_mode.gcm.wc_aes_gcm_dec;
-  byte* authIn = c->u_mode.gcm.authIn;
-  unsigned int authInSz = c->u_mode.gcm.authInSz;
-
-  _wc_init_aes_gcm(c);
-
-  ret = wc_AesGcmDecryptUpdate(dec, outbuf, inbuf, inbuflen, NULL, 0);
-  if (ret != 0) {
-    printf("wc_AesGcmEncrypt failed: %d\n", ret);
-    return;
-  }
-  /* To tell last operation was decrypt */
-  c->u_mode.gcm.wcAesEncrypt = 0;
-  c->u_mode.gcm.wcAesDecrypt = 1;
-
-  return ret;
-
-}
-
 
 gcry_err_code_t
 _wc_cipher_aes_gcm_setiv (gcry_cipher_hd_t c, const byte *iv, size_t ivlen)
 {
-  int ret = 0;
-  //prinft*"wc_cipher_aes_gcm_setiv*******\n");
-  if (ivlen <= 0) {
+  int ret;
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
+  Aes *aesGcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
+  unsigned char *aadbuf = (wc_c->aadbuf_len > 0) ? wc_c->aadbuf : NULL;
+
+  c->marks.iv = 0;
+  c->marks.tag = 0;
+  memset (c->u_mode.gcm.aadlen, 0, sizeof(c->u_mode.gcm.aadlen));
+  memset (c->u_mode.gcm.datalen, 0, sizeof(c->u_mode.gcm.datalen));
+  memset (c->u_mode.gcm.u_tag.tag, 0, GCRY_GCM_BLOCK_LEN);
+  c->u_mode.gcm.datalen_over_limits = 0;
+  c->u_mode.gcm.ghash_data_finalized = 0;
+  c->u_mode.gcm.ghash_aad_finalized = 0;
+
+  if (ivlen == 0)
     return GPG_ERR_INV_LENGTH;
-  }
-  if (iv == NULL) {
-    printf("wc_cipher_aes_gcm_setiv: Invalid iv: NULL\n");
-    return GPG_ERR_INV_ARG;
-  }
 
-  /* explicitly free the iv buffer if it is not null */
-  if (c->u_mode.gcm.iv != NULL) {
-    free(c->u_mode.gcm.iv);
-    c->u_mode.gcm.iv = NULL;
-  }
+  if (ivlen != GCRY_GCM_BLOCK_LEN - 4) {
+    u32 iv_bytes[2] = {0, 0};
 
-  c->u_mode.gcm.iv = (byte*)malloc(ivlen);
-  if (c->u_mode.gcm.iv == NULL) {
-    printf("Failed to allocate memory for iv\n");
-    return GPG_ERR_INV_STATE;
+    gcm_bytecounter_add(iv_bytes, ivlen);
+    if (!gcm_check_aadlen_or_ivlen(iv_bytes))
+    {
+      c->u_mode.gcm.datalen_over_limits = 1;
+      return GPG_ERR_INV_LENGTH;
+    }
   }
 
-  memcpy(c->u_mode.gcm.iv, iv, ivlen);
-  c->u_mode.gcm.ivSz = ivlen;
+  if (wc_c->iv)
+    free(wc_c->iv);
 
-  /* Reinitialize the context */
-  c->u_mode.gcm.wcAesGcmInit = 0;
-  _wc_init_aes_gcm(c);
+  wc_c->iv_len = 0;
 
-  return 0;
+  wc_c->iv = calloc(ivlen, sizeof *wc_c->iv);
+  if (wc_c->iv == NULL) {
+    wc_c->iv_len = 0;
+    return GPG_ERR_INV_VALUE;
+  }
+
+  memcpy(wc_c->iv, iv, ivlen);
+  wc_c->iv_len = ivlen;
+
+  c->unused = 0;
+  c->marks.iv = 1;
+  c->marks.tag = 0;
+
+
+  ret = wc_AesGcmEncrypt(aesGcmEnc, NULL,
+                         NULL, 0,
+                         wc_c->iv, wc_c->iv_len,
+                         wc_c->authtag, GCRY_GCM_BLOCK_LEN,
+                         aadbuf, wc_c->aadbuf_len);
+  if (ret)
+    return GPG_ERR_INV_VALUE;
+
+  return GPG_ERR_NO_ERROR;
 }
 
+gcry_err_code_t
+_wc_cipher_aes_gcm_setiv_zero (gcry_cipher_hd_t c)
+{
+  static const unsigned char zerobuf[MAX_BLOCKSIZE];
+
+  c->u_mode.gcm.disallow_encryption_because_of_setiv_in_fips_mode = 0;
+
+  if (fips_mode ())
+    {
+      /* Direct invocation of GCM setiv in FIPS mode disables encryption. */
+      c->u_mode.gcm.disallow_encryption_because_of_setiv_in_fips_mode = 1;
+    }
+
+  return _wc_cipher_aes_gcm_setiv (c, zerobuf, GCRY_GCM_BLOCK_LEN);
+}
 
 gcry_err_code_t
 _wc_cipher_aes_gcm_authenticate (gcry_cipher_hd_t c,
-                               const byte *aadbuf, size_t aadbuflen)
+                               const byte * aadbuf, size_t aadbuflen)
 {
-  Aes* enc = &c->u_mode.gcm.wc_aes_gcm_enc;
-  Aes* dec = &c->u_mode.gcm.wc_aes_gcm_dec;
-  int ret = 0;
-
-  if (aadbuflen == 0) {
-    return 0;
-  }
-  if (aadbuf == NULL) {
-    return 0;
-  }
-  _wc_init_aes_gcm(c);
-
-  /* Calculate new total size */
-  ret = wc_AesGcmEncryptUpdate(enc, NULL, NULL, 0, aadbuf, aadbuflen);
-  if (ret != 0) {
-    printf("wc_AesGcmEncryptUpdate failed: %d\n", ret);
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
+  if (c->spec->blocksize != GCRY_GCM_BLOCK_LEN)
+    return GPG_ERR_CIPHER_ALGO;
+  if (c->u_mode.gcm.datalen_over_limits)
+    return GPG_ERR_INV_LENGTH;
+  if (c->marks.tag
+      || c->u_mode.gcm.ghash_aad_finalized
+      || c->u_mode.gcm.ghash_data_finalized)
     return GPG_ERR_INV_STATE;
+
+  if (!c->marks.iv && fips_mode())
+    _wc_cipher_aes_gcm_setiv_zero(c);
+
+  if (wc_c->aadbuf == NULL) {
+    size_t aadbufcap = 256 > aadbuflen ? 256 : aadbuflen;
+    wc_c->aadbuf = calloc(aadbufcap, sizeof *wc_c->aadbuf);
+    wc_c->aadbuf_cap = aadbufcap;
   }
-  ret = wc_AesGcmDecryptUpdate(dec, NULL, NULL, 0, aadbuf, aadbuflen);
-  if (ret != 0) {
-    printf("wc_AesGcmDecryptUpdate failed: %d\n", ret);
-    return GPG_ERR_INV_STATE;
+
+  if (wc_c->aadbuf_len + aadbuflen > wc_c->aadbuf_cap) {
+    size_t aadbufcap = wc_c->aadbuf_cap + 256 > wc_c->aadbuf_cap + aadbuflen ?
+      wc_c->aadbuf_cap + 256 : wc_c->aadbuf_cap + aadbuflen;
+    wc_c->aadbuf = realloc(wc_c->aadbuf, aadbufcap);
   }
+
+  memcpy(&wc_c->aadbuf[wc_c->aadbuf_len], aadbuf, aadbuflen);
+  wc_c->aadbuf_len += aadbuflen;
+
   return 0;
 }
 
-/* Do shallow copy of the aes context */
+gcry_err_code_t
+_wc_cipher_aes_gcm_encrypt (gcry_cipher_hd_t c,
+                          byte *outbuf, size_t outbuflen,
+                          const byte *inbuf, size_t inbuflen)
+{
+  int ret;
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
+  Aes *aesGcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
+  unsigned char *aadbuf = (wc_c->aadbuf_len > 0) ? wc_c->aadbuf : NULL;
+  size_t newdatastart;
+
+  if (c->spec->blocksize != GCRY_GCM_BLOCK_LEN)
+    return GPG_ERR_CIPHER_ALGO;
+  if (outbuflen < inbuflen)
+    return GPG_ERR_BUFFER_TOO_SHORT;
+  if (c->u_mode.gcm.datalen_over_limits)
+    return GPG_ERR_INV_LENGTH;
+  if (c->marks.tag
+      || c->u_mode.gcm.ghash_data_finalized)
+    return GPG_ERR_INV_STATE;
+
+  if (!c->marks.iv)
+    _wc_cipher_aes_gcm_setiv_zero(c);
+
+  if (c->u_mode.gcm.disallow_encryption_because_of_setiv_in_fips_mode)
+    return GPG_ERR_INV_STATE;
+
+  ret = _wc_realloc_if_needed(wc_c, outbuflen, inbuflen);
+  if (ret)
+    return ret;
+
+  memcpy(&wc_c->databuf[wc_c->databuf_len], inbuf, inbuflen);
+  newdatastart = wc_c->databuf_len;
+  wc_c->databuf_len += inbuflen;
+
+  ret = wc_AesGcmEncrypt(aesGcmEnc, wc_c->cryptbuf,
+                         wc_c->databuf, wc_c->databuf_len,
+                         wc_c->iv, wc_c->iv_len,
+                         wc_c->authtag, GCRY_GCM_BLOCK_LEN,
+                         aadbuf, wc_c->aadbuf_len);
+  if (ret != 0)
+    return GPG_ERR_INV_ARG;
+
+  wc_c->cryptbuf_len += inbuflen;
+  memcpy(outbuf, &wc_c->cryptbuf[newdatastart], inbuflen);
+  return GPG_ERR_NO_ERROR;
+}
+
+gcry_err_code_t
+_wc_cipher_aes_gcm_decrypt (gcry_cipher_hd_t c,
+                          byte *outbuf, size_t outbuflen,
+                          const byte *inbuf, size_t inbuflen)
+{
+  int ret;
+  Aes *aesGcmDec = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_dec);
+  Aes *aesGcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
+  unsigned char *aadbuf = (wc_c->aadbuf_len > 0) ? wc_c->aadbuf : NULL;
+  size_t newdatastart;
+
+  if (c->spec->blocksize != GCRY_GCM_BLOCK_LEN)
+    return GPG_ERR_CIPHER_ALGO;
+  if (outbuflen < inbuflen)
+    return GPG_ERR_BUFFER_TOO_SHORT;
+  if (c->u_mode.gcm.datalen_over_limits)
+    return GPG_ERR_INV_LENGTH;
+  if (c->marks.tag
+      || c->u_mode.gcm.ghash_data_finalized)
+    return GPG_ERR_INV_STATE;
+
+  if (!c->marks.iv)
+    _wc_cipher_aes_gcm_setiv_zero(c);
+
+  ret = _wc_realloc_if_needed(wc_c, outbuflen, inbuflen);
+  if (ret)
+    return ret;
+
+  memcpy(&wc_c->databuf[wc_c->databuf_len], inbuf, inbuflen);
+
+  newdatastart = wc_c->databuf_len;
+  wc_c->databuf_len += inbuflen;
+
+  ret = wc_AesGcmDecrypt(aesGcmDec, wc_c->cryptbuf,
+                         wc_c->databuf, wc_c->databuf_len,
+                         wc_c->iv, wc_c->iv_len,
+                         wc_c->authtag, GCRY_GCM_BLOCK_LEN,
+                         aadbuf, wc_c->aadbuf_len);
+  if (ret != -181) {
+    ret = wc_AesGcmEncrypt(aesGcmEnc, wc_c->databuf,
+                           wc_c->cryptbuf, wc_c->databuf_len,
+                           wc_c->iv, wc_c->iv_len,
+                           wc_c->authtag, GCRY_GCM_BLOCK_LEN,
+                           aadbuf, wc_c->aadbuf_len);
+  }
+
+  wc_c->cryptbuf_len += inbuflen;
+  memcpy(outbuf, &wc_c->cryptbuf[newdatastart], inbuflen);
+
+  return GPG_ERR_NO_ERROR;
+}
+
+static gcry_err_code_t
+_wc_cipher_aes_gcm_tag (gcry_cipher_hd_t c,
+                      byte * outbuf, size_t outbuflen, int check)
+{
+  wc_gcm_context_t *wc_c = &c->u_mode.gcm.wc_gcm;
+  if (!(is_tag_length_valid (outbuflen) || outbuflen >= GCRY_GCM_BLOCK_LEN))
+    return GPG_ERR_INV_LENGTH;
+  if (c->u_mode.gcm.datalen_over_limits)
+    return GPG_ERR_INV_LENGTH;
+
+  if (!check)
+    {
+      if (outbuflen > GCRY_GCM_BLOCK_LEN)
+        outbuflen = GCRY_GCM_BLOCK_LEN;
+
+      /* NB: We already checked that OUTBUF is large enough to hold
+       * the result or has valid truncated length.  */
+      memcpy (outbuf, wc_c->authtag, outbuflen);
+    }
+  else
+    {
+      /* OUTBUFLEN gives the length of the user supplied tag in OUTBUF
+       * and thus we need to compare its length first.  */
+      if (!is_tag_length_valid (outbuflen)
+          || !buf_eq_const (outbuf, wc_c->authtag, outbuflen))
+        return GPG_ERR_CHECKSUM;
+    }
+
+  return 0;
+}
+
+
 gcry_err_code_t
 _wc_cipher_aes_gcm_get_tag (gcry_cipher_hd_t c, unsigned char *outtag,
                           size_t taglen)
 {
-  int ret = 0;
-  Aes encCpy;
-
-  if (!(is_tag_length_valid (taglen) || taglen >= GCRY_GCM_BLOCK_LEN)) {
-    return GPG_ERR_INV_LENGTH;
-  }
-  /* if greater then reduce down to 16 */
-  if (taglen > 16) {
-    taglen = 16;
-  }
-
-
-  if (outtag == NULL) {
-    return GPG_ERR_INV_ARG;
-  }
-  _wc_init_aes_gcm(c);
-  memcpy(&encCpy, &c->u_mode.gcm.wc_aes_gcm_enc, sizeof(Aes));
-  ret = wc_AesGcmEncryptFinal(&encCpy, outtag, taglen);
-  if (ret != 0) {
-    printf("wc_AesGcmEncryptFinal failed: %d\n", ret);
+  /* Outputting authentication tag is part of encryption. */
+  if (c->u_mode.gcm.disallow_encryption_because_of_setiv_in_fips_mode)
     return GPG_ERR_INV_STATE;
-  }
-  return 0;
+
+  return _wc_cipher_aes_gcm_tag (c, outtag, taglen, 0);
 }
 
-/* Do shallow copy of the aes context */
 gcry_err_code_t
 _wc_cipher_aes_gcm_check_tag (gcry_cipher_hd_t c, const unsigned char *intag,
                             size_t taglen)
 {
-  int ret = 0;
-  Aes decCpy;
-
-  if (!(is_tag_length_valid (taglen) || taglen >= GCRY_GCM_BLOCK_LEN)) {
-    return GPG_ERR_INV_LENGTH;
-  }
-  if (taglen > 16) {
-    return GPG_ERR_INV_LENGTH;
-  }
-  if (intag == NULL) {
-    return GPG_ERR_INV_ARG;
-  }
-  _wc_init_aes_gcm(c);
-  memcpy(&decCpy, &c->u_mode.gcm.wc_aes_gcm_dec, sizeof(Aes));
-  ret = wc_AesGcmDecryptFinal(&c->u_mode.gcm.wc_aes_gcm_dec, intag, taglen);
-  if (ret != 0) {
-    printf("wc_AesGcmDecryptFinal failed: %d\n", ret);
-    return GPG_ERR_CHECKSUM;
-  }
-  return 0;
-}
-
-
-
-
-
-void
-_wc_cipher_aes_gcm_setupM (gcry_cipher_hd_t c)
-{
-  c->u_mode.gcm.ghash_fn = NULL;
-  c->u_mode.gcm.polyval_fn = NULL;
-  if (c->u_mode.gcm.ghash_fn == NULL)
-    {
-      c->u_mode.gcm.ghash_fn = ghash_internal;
-      fillM (c);
-    }
-}
-
-
-
-
-
-/* A key always needs to be set so lets do all the initialization here */
-void
-_wc_cipher_aes_gcm_setkey (gcry_cipher_hd_t c, const byte *key, size_t keylen)
-{
-  int ret = 0;
-  //prinft*"wc_cipher_aes_gcm_setkey*******\n");
-  /* Check key length */
-  if (keylen != 16 && keylen != 24 && keylen != 32) {
-    printf("wc_cipher_aes_gcm_setkey: Invalid key length\n");
-    return;
-  }
-
-  if (c->u_mode.gcm.key != NULL) {
-    free(c->u_mode.gcm.key);
-    c->u_mode.gcm.key = NULL;
-  }
-
-  c->u_mode.gcm.key = (byte*)malloc(keylen);
-  if (c->u_mode.gcm.key == NULL) {
-    printf("Failed to allocate memory for key\n");
-    return;
-  }
-
-  memcpy(c->u_mode.gcm.key, key, keylen);
-  memcpy(&c->u_mode.gcm.keySz, &keylen, sizeof(keylen));
-
-  return;
+  return _wc_cipher_aes_gcm_tag (c, (unsigned char *) intag, taglen, 1);
 }
 
 #endif

--- a/cipher/cipher-internal.h
+++ b/cipher/cipher-internal.h
@@ -134,6 +134,7 @@
 #endif
 #endif /* GCM_USE_PPC_VPMSUM */
 
+#ifdef HAVE_WOLFSSL
 typedef struct wc_ccm_context {
     unsigned char *databuf;
     size_t databuf_len;
@@ -151,6 +152,26 @@ typedef struct wc_ccm_context {
     size_t authtag_len;
 } wc_ccm_context_t;
 
+typedef struct wc_gcm_context {
+    unsigned char *iv;
+    size_t iv_len;
+
+    unsigned char *databuf;
+    size_t databuf_len;
+    size_t databuf_cap;
+
+    unsigned char *cryptbuf;
+    size_t cryptbuf_len;
+    size_t cryptbuf_cap;
+
+    unsigned char *aadbuf;
+    size_t aadbuf_len;
+    size_t aadbuf_cap;
+
+    unsigned char authtag[16];
+} wc_gcm_context_t;
+
+#endif
 typedef unsigned int (*ghash_fn_t) (gcry_cipher_hd_t c, byte *result,
                                     const byte *buf, size_t nblocks);
 
@@ -382,23 +403,7 @@ struct gcry_cipher_handle
 
       /* wolfSSL AES GCM context */
       #ifdef HAVE_WOLFSSL
-      Aes wc_aes_gcm_enc;
-      Aes wc_aes_gcm_dec;
-
-      byte* key;
-      unsigned int keySz;
-
-      byte* iv;
-      unsigned int ivSz;
-
-      byte* authIn;
-      unsigned int authInSz;
-
-      byte authTag[16];
-      unsigned int authTagSz;
-      unsigned int wcAesGcmInit:1;
-      unsigned int wcAesEncrypt:1;
-      unsigned int wcAesDecrypt:1;
+      wc_gcm_context_t wc_gcm;
       #endif
 
       /* GHASH multiplier from key.  */
@@ -683,6 +688,18 @@ gcry_err_code_t _gcry_cipher_eax_setkey
 
 /*-- cipher-gcm.c --*/
 #ifdef HAVE_WOLFSSL
+gcry_err_code_t _wc_cipher_aes_gcm_close
+/*           */   (gcry_cipher_hd_t c);
+gcry_err_code_t _wc_cipher_aes_gcm_reset
+/*           */   (gcry_cipher_hd_t c);
+gcry_err_code_t _wc_cipher_aes_gcm_setkey
+/*           */   (gcry_cipher_hd_t c, const byte *key, size_t keylen);
+gcry_err_code_t _wc_cipher_aes_gcm_setiv
+/*           */   (gcry_cipher_hd_t c,
+                   const unsigned char *iv, size_t ivlen);
+gcry_err_code_t _wc_cipher_aes_gcm_authenticate
+/*           */   (gcry_cipher_hd_t c,
+                   const unsigned char *aadbuf, size_t aadbuflen);
 gcry_err_code_t _wc_cipher_aes_gcm_encrypt
 /*           */   (gcry_cipher_hd_t c,
                    unsigned char *outbuf, size_t outbuflen,
@@ -694,20 +711,12 @@ gcry_err_code_t _wc_cipher_aes_gcm_decrypt
 gcry_err_code_t _wc_cipher_aes_gcm_setiv
 /*           */   (gcry_cipher_hd_t c,
                    const unsigned char *iv, size_t ivlen);
-gcry_err_code_t _wc_cipher_aes_gcm_authenticate
-/*           */   (gcry_cipher_hd_t c,
-                   const unsigned char *aadbuf, size_t aadbuflen);
 gcry_err_code_t _wc_cipher_aes_gcm_get_tag
 /*           */   (gcry_cipher_hd_t c,
                    unsigned char *outtag, size_t taglen);
 gcry_err_code_t _wc_cipher_aes_gcm_check_tag
 /*           */   (gcry_cipher_hd_t c,
                    const unsigned char *intag, size_t taglen);
-void _wc_cipher_aes_gcm_setkey
-/*           */   (gcry_cipher_hd_t c, const byte *key, size_t keylen);
-void _wc_cipher_aes_gcm_setupM
-/*           */   (gcry_cipher_hd_t c);
-void _wc_cipher_aes_gcm_reset(gcry_cipher_hd_t c);
 #endif
 
 gcry_err_code_t _gcry_cipher_gcm_encrypt

--- a/cipher/cipher.c
+++ b/cipher/cipher.c
@@ -740,26 +740,13 @@ _gcry_cipher_close (gcry_cipher_hd_t h)
   /* do this only for AESGCM mode */
   if (h->mode == GCRY_CIPHER_MODE_GCM) {
     switch (h->spec->algo) {
+      #ifdef HAVE_WOLFSSL
       case GCRY_CIPHER_AES:
       case GCRY_CIPHER_AES192:
       case GCRY_CIPHER_AES256:
-        /* explicitly free the authIn buffer */
-        if (h->u_mode.gcm.authIn != NULL) {
-          free(h->u_mode.gcm.authIn);
-          h->u_mode.gcm.authIn = NULL;
-        }
-
-        /* explicitly free the iv buffer */
-        if (h->u_mode.gcm.iv != NULL) {
-          free(h->u_mode.gcm.iv);
-          h->u_mode.gcm.iv = NULL;
-        }
-
-        if (h->u_mode.gcm.key != NULL) {
-          free(h->u_mode.gcm.key);
-          h->u_mode.gcm.key = NULL;
-        }
+        _wc_cipher_aes_gcm_close(h);
         break;
+      #endif
       default:
         break;
     }


### PR DESCRIPTION
This implements AES GCM support.

Tested with wolfssl build with the following configuration
```
./configure --prefix=/home/alex/Repos/wolfssl-org/osp/libgcrypt/wolfssl-install --enable-aesctr --enable-aesccm --enable-aesofb --enable-debug-trace-errcodes --enable-keygen --enable-rsa --disable-harden --enable-cmac 'CFLAGS=-DHAVE_AES_ECB -DWOLFSSL_AESGCM_STREAM -DWC_RSA_DIRECT -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DWOLFSSL_RSA_KEY_CHECK -DHAVE_FIPS_VERSION=5 -DACVP_VECTOR_TESTING'
```