### PR TITLE
Libgcrypt 1.11.0 wolfcrypt ecc

### DIFF
--- a/cipher/ecc-ecdsa.c
+++ b/cipher/ecc-ecdsa.c
@@ -37,6 +37,8 @@
  * Return the signature struct (r,s) from the message hash.  The caller
  * must have allocated R and S.
  */
+
+#ifndef HAVE_WOLFSSL
 gpg_err_code_t
 _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
                       gcry_mpi_t r, gcry_mpi_t s,
@@ -303,3 +305,276 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
 
   return err;
 }
+
+#else
+/* wolfSSL implementation */
+gpg_err_code_t
+_gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
+                      gcry_mpi_t r, gcry_mpi_t s,
+                      int flags, int hashalgo)
+{
+  gpg_err_code_t rc = 0;
+  int extraloops = 0;
+  gcry_mpi_t k, dr, sum, k_1, x;
+  mpi_point_struct I;
+  gcry_mpi_t hash;
+  const void *abuf;
+  unsigned int abits, qbits;
+  gcry_mpi_t b;                /* Random number needed for blinding.  */
+  gcry_mpi_t bi;               /* multiplicative inverse of B.        */
+  gcry_mpi_t hash_computed_internally = NULL;
+
+  if (DBG_CIPHER)
+    log_mpidump ("ecdsa sign hash  ", input );
+
+  qbits = mpi_get_nbits (ec->n);
+
+  if ((flags & PUBKEY_FLAG_PREHASH))
+    {
+      rc = _gcry_dsa_compute_hash (&hash_computed_internally, input, hashalgo);
+      if (rc)
+        return rc;
+      input = hash_computed_internally;
+    }
+
+  /* Convert the INPUT into an MPI if needed.  */
+  rc = _gcry_dsa_normalize_hash (input, &hash, qbits);
+
+  if (rc)
+    {
+      mpi_free (hash_computed_internally);
+      return rc;
+    }
+
+  b  = mpi_snew (qbits);
+  bi = mpi_snew (qbits);
+  do
+    {
+      _gcry_mpi_randomize (b, qbits, GCRY_WEAK_RANDOM);
+      mpi_mod (b, b, ec->n);
+    }
+  while (!mpi_invm (bi, b, ec->n));
+
+  k = NULL;
+  dr = mpi_alloc (0);
+  sum = mpi_alloc (0);
+  k_1 = mpi_alloc (0);
+  x = mpi_alloc (0);
+  point_init (&I);
+
+  /* Two loops to avoid R or S are zero.  This is more of a joke than
+     a real demand because the probability of them being zero is less
+     than any hardware failure.  Some specs however require it.  */
+  while (1)
+    {
+      while (1)
+        {
+          if (k_supplied)
+            k = k_supplied;
+          else
+            {
+              mpi_free (k);
+              k = NULL;
+              if ((flags & PUBKEY_FLAG_RFC6979) && hashalgo)
+                {
+                  if (fips_mode () &&
+                      (hashalgo == GCRY_MD_SHAKE128
+                       || hashalgo == GCRY_MD_SHAKE256))
+                    {
+                      rc = GPG_ERR_DIGEST_ALGO;
+                      goto leave;
+                    }
+
+                  /* Use Pornin's method for deterministic DSA.  If this
+                     flag is set, it is expected that HASH is an opaque
+                     MPI with the to be signed hash.  That hash is also
+                     used as h1 from 3.2.a.  */
+                  if (!mpi_is_opaque (input))
+                    {
+                      rc = GPG_ERR_CONFLICT;
+                      goto leave;
+                    }
+
+                  abuf = mpi_get_opaque (input, &abits);
+                  rc = _gcry_dsa_gen_rfc6979_k (&k, ec->n, ec->d,
+                                                abuf, (abits+7)/8,
+                                                hashalgo, extraloops);
+                  if (rc)
+                    goto leave;
+                  extraloops++;
+                }
+              else
+                k = _gcry_dsa_gen_k (ec->n, GCRY_STRONG_RANDOM);
+            }
+
+          mpi_invm (k_1, k, ec->n);     /* k_1 = k^(-1) mod n  */
+
+          _gcry_dsa_modify_k (k, ec->n, qbits);
+
+          _gcry_mpi_ec_mul_point (&I, k, ec->G, ec);
+          if (_gcry_mpi_ec_get_affine (x, NULL, &I, ec))
+            {
+              if (DBG_CIPHER)
+                log_debug ("ecc sign: Failed to get affine coordinates\n");
+              rc = GPG_ERR_BAD_SIGNATURE;
+              goto leave;
+            }
+          mpi_mod (r, x, ec->n);  /* r = x mod n */
+
+          if (mpi_cmp_ui (r, 0))
+            break;
+
+          if (k_supplied)
+            {
+              rc = GPG_ERR_INV_VALUE;
+              goto leave;
+            }
+        }
+
+      /* Computation of dr, sum, and s are blinded with b.  */
+      mpi_mulm (dr, b, ec->d, ec->n);
+      mpi_mulm (dr, dr, r, ec->n);      /* dr = d*r mod n */
+      mpi_mulm (sum, b, hash, ec->n);
+      mpi_addm (sum, sum, dr, ec->n);   /* sum = hash + (d*r) mod n */
+      mpi_mulm (s, k_1, sum, ec->n);    /* s = k^(-1)*(hash+(d*r)) mod n */
+      /* Undo blinding by b^-1 */
+      mpi_mulm (s, bi, s, ec->n);
+      if (mpi_cmp_ui (s, 0))
+        break;
+
+      if (k_supplied)
+        {
+          rc = GPG_ERR_INV_VALUE;
+          break;
+        }
+    }
+
+  if (DBG_CIPHER)
+    {
+      log_mpidump ("ecdsa sign result r ", r);
+      log_mpidump ("ecdsa sign result s ", s);
+    }
+
+ leave:
+  mpi_free (b);
+  mpi_free (bi);
+  point_free (&I);
+  mpi_free (x);
+  mpi_free (k_1);
+  mpi_free (sum);
+  mpi_free (dr);
+  if (!k_supplied)
+    mpi_free (k);
+
+  if (hash != input)
+    mpi_free (hash);
+  mpi_free (hash_computed_internally);
+
+  return rc;
+}
+
+
+/* Verify an ECDSA signature.
+ * Check if R and S verifies INPUT.
+ */
+gpg_err_code_t
+_gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
+                        gcry_mpi_t r, gcry_mpi_t s, int flags, int hashalgo)
+{
+  gpg_err_code_t err = 0;
+  gcry_mpi_t hash, h, h1, h2, x;
+  mpi_point_struct Q, Q1, Q2;
+  unsigned int nbits;
+  gcry_mpi_t hash_computed_internally = NULL;
+
+  if (!_gcry_mpi_ec_curve_point (ec->Q, ec))
+    return GPG_ERR_BROKEN_PUBKEY;
+
+  if( !(mpi_cmp_ui (r, 0) > 0 && mpi_cmp (r, ec->n) < 0) )
+    return GPG_ERR_BAD_SIGNATURE; /* Assertion	0 < r < n  failed.  */
+  if( !(mpi_cmp_ui (s, 0) > 0 && mpi_cmp (s, ec->n) < 0) )
+    return GPG_ERR_BAD_SIGNATURE; /* Assertion	0 < s < n  failed.  */
+
+  nbits = mpi_get_nbits (ec->n);
+  if ((flags & PUBKEY_FLAG_PREHASH))
+    {
+      err = _gcry_dsa_compute_hash (&hash_computed_internally, input,
+                                    hashalgo);
+      if (err)
+        return err;
+      input = hash_computed_internally;
+    }
+
+  err = _gcry_dsa_normalize_hash (input, &hash, nbits);
+  if (err)
+    {
+      mpi_free (hash_computed_internally);
+      return err;
+    }
+
+  h  = mpi_alloc (0);
+  h1 = mpi_alloc (0);
+  h2 = mpi_alloc (0);
+  x = mpi_alloc (0);
+  point_init (&Q);
+  point_init (&Q1);
+  point_init (&Q2);
+
+  /* h  = s^(-1) (mod n) */
+  mpi_invm (h, s, ec->n);
+  /* h1 = hash * s^(-1) (mod n) */
+  mpi_mulm (h1, hash, h, ec->n);
+  /* Q1 = [ hash * s^(-1) ]G  */
+  _gcry_mpi_ec_mul_point (&Q1, h1, ec->G, ec);
+  /* h2 = r * s^(-1) (mod n) */
+  mpi_mulm (h2, r, h, ec->n);
+  /* Q2 = [ r * s^(-1) ]Q */
+  _gcry_mpi_ec_mul_point (&Q2, h2, ec->Q, ec);
+  /* Q  = ([hash * s^(-1)]G) + ([r * s^(-1)]Q) */
+  _gcry_mpi_ec_add_points (&Q, &Q1, &Q2, ec);
+
+  if (!mpi_cmp_ui (Q.z, 0))
+    {
+      if (DBG_CIPHER)
+          log_debug ("ecc verify: Rejected\n");
+      err = GPG_ERR_BAD_SIGNATURE;
+      goto leave;
+    }
+  if (_gcry_mpi_ec_get_affine (x, NULL, &Q, ec))
+    {
+      if (DBG_CIPHER)
+        log_debug ("ecc verify: Failed to get affine coordinates\n");
+      err = GPG_ERR_BAD_SIGNATURE;
+      goto leave;
+    }
+  mpi_mod (x, x, ec->n); /* x = x mod E_n */
+  if (mpi_cmp (x, r))   /* x != r */
+    {
+      if (DBG_CIPHER)
+        {
+          log_mpidump ("     x", x);
+          log_mpidump ("     r", r);
+          log_mpidump ("     s", s);
+        }
+      err = GPG_ERR_BAD_SIGNATURE;
+      goto leave;
+    }
+
+ leave:
+  point_free (&Q2);
+  point_free (&Q1);
+  point_free (&Q);
+  mpi_free (x);
+  mpi_free (h2);
+  mpi_free (h1);
+  mpi_free (h);
+  if (hash != input)
+    mpi_free (hash);
+  mpi_free (hash_computed_internally);
+
+  return err;
+}
+
+
+
+#endif

--- a/cipher/ecc-ecdsa.c
+++ b/cipher/ecc-ecdsa.c
@@ -337,35 +337,30 @@ wc_name_to_curve_id(const char *curve_name)
     if (strcmp(curve_name, "NIST P-192") == 0 ||
         strcmp(curve_name, "secp192r1") == 0 ||
         strcmp(curve_name, "nistp192") == 0) {
-      //printf("wc_name_to_curve_id: NIST P-192\n");
       return ECC_SECP192R1;
     }
 
     if (strcmp(curve_name, "NIST P-224") == 0 ||
         strcmp(curve_name, "secp224r1") == 0 ||
         strcmp(curve_name, "nistp224") == 0) {
-      //printf("wc_name_to_curve_id: NIST P-224\n");
       return ECC_SECP224R1;
     }
 
     if (strcmp(curve_name, "NIST P-256") == 0 ||
         strcmp(curve_name, "secp256r1") == 0 ||
         strcmp(curve_name, "nistp256") == 0) {
-      //printf("wc_name_to_curve_id: NIST P-256\n");
       return ECC_SECP256R1;
     }
 
     if (strcmp(curve_name, "NIST P-384") == 0 ||
         strcmp(curve_name, "secp384r1") == 0 ||
         strcmp(curve_name, "nistp384") == 0) {
-      //printf("wc_name_to_curve_id: NIST P-384\n");
       return ECC_SECP384R1;
     }
 
     if (strcmp(curve_name, "NIST P-521") == 0 ||
         strcmp(curve_name, "secp521r1") == 0 ||
         strcmp(curve_name, "nistp521") == 0) {
-      //printf("wc_name_to_curve_id: NIST P-521\n");
       return ECC_SECP521R1;
     }
 
@@ -583,7 +578,111 @@ _libgcrypt_hash_length(int gcry_hash_algo)
   }
 }
 
+/* Way to convert wolfSSL mpi to libgcrypt mpi */
+static int
+_wc_mpi_to_libgcrypt_mpi(mp_int *wc_mpi, gcry_mpi_t gcry_mpi)
+{
+  int ret = 0;
 
+  /* Temp Buffer for conversion */
+  word32 mpi_len = 0;
+  byte* mpi_bin = NULL;
+
+  /* Temp libgcrypt mpi */
+  gcry_mpi_t temp_mpi;
+
+  ret = mp_unsigned_bin_size(wc_mpi);
+  if (ret <= 0) {
+    return GPG_ERR_ENOMEM;
+  }
+  else {
+    /* cast to word32 */
+    mpi_len = (word32)ret;
+  }
+
+  /* allocate memory for the temp buffer */
+  mpi_bin = (byte*)XMALLOC(mpi_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+  if (mpi_bin == NULL) {
+    return GPG_ERR_ENOMEM;
+  }
+
+  ret = mp_to_unsigned_bin(wc_mpi, mpi_bin);
+  if (ret != 0) {
+    XFREE(mpi_bin, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return ret;
+  }
+
+  /* convert the temp buffer to libgcrypt mpi */
+  ret = _gcry_mpi_scan(&temp_mpi, GCRYMPI_FMT_USG, mpi_bin, mpi_len, NULL);
+  if (ret != 0) {
+    XFREE(mpi_bin, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return ret;
+  }
+
+  XFREE(mpi_bin, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+  /* Explicitly set the libgcrypt mpi to the temp mpi */
+  /* to avoid and copy issues */
+  _gcry_mpi_set(gcry_mpi, temp_mpi);
+
+
+  return ret;
+}
+
+/* need to convert libgcrypt mpi to wolfSSL mpi */
+/* must pass a lenght of the expected char array */
+/* Can be 0 if not needed, but used for right aligning */
+static int
+_libgcrypt_mpi_to_wc_mpi(gcry_mpi_t gcry_mpi, mp_int *wc_mpi, word32 wc_mpi_len)
+{
+  int ret = 0;
+  byte* mpi_bin = NULL;
+  size_t mpi_bin_len = 0;
+  byte* mpi_bin_rightAligned = NULL;
+  word32 mpi_bin_rightAligned_len = 0;
+
+  ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &mpi_bin, &mpi_bin_len, gcry_mpi);
+  if (ret != 0) {
+    return ret;
+  }
+
+  if (wc_mpi_len > 0) {
+    mpi_bin_rightAligned_len = wc_mpi_len;
+    mpi_bin_rightAligned = (byte*)XMALLOC(mpi_bin_rightAligned_len, NULL,
+                                            DYNAMIC_TYPE_TMP_BUFFER);
+    if (mpi_bin_rightAligned == NULL) {
+      _gcry_free(mpi_bin);
+      return GPG_ERR_ENOMEM;
+    }
+    XMEMSET(mpi_bin_rightAligned, 0, mpi_bin_rightAligned_len);
+
+    memcpy(mpi_bin_rightAligned + (mpi_bin_rightAligned_len - mpi_bin_len),
+                mpi_bin, mpi_bin_len);
+
+  }
+  else {
+    /* just use the original pointer */
+    mpi_bin_rightAligned = mpi_bin;
+    mpi_bin_rightAligned_len = mpi_bin_len;
+  }
+
+
+  ret = mp_read_unsigned_bin(wc_mpi, mpi_bin_rightAligned,
+                                mpi_bin_rightAligned_len);
+
+  /* Only free if we allocated the right aligned buffer */
+  if (wc_mpi_len > 0 && mpi_bin_rightAligned != mpi_bin) {
+    XFREE(mpi_bin_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+  }
+  _gcry_free(mpi_bin);
+
+  return ret;
+}
+
+
+#define WC_MAX_CURVE_SIZE (528/8) /* 528 bits = 66 bytes */
+                                    /* Max Curver supported is P-521 */
+                                    /* So 66 bytes is the max size */
 
 /* Copy original function name from libgcrypt */
 /* As code is called from libgcrypt and not switchable function pointers */
@@ -610,25 +709,22 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
   int wolf = 0;
   ecc_curve_id wc_curve_id = ECC_CURVE_INVALID; /* no curve id */
 
-  byte *wc_QX = NULL;
-  byte *wc_QY = NULL;
-  byte *wc_D = NULL;
-  byte *wc_QX_rightAligned = NULL;
-  byte *wc_QY_rightAligned = NULL;
-  byte *wc_D_rightAligned = NULL;
-  byte *wc_r = NULL;
-  byte *wc_s = NULL;
-  byte *wc_k = NULL;
+  byte wc_D[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_QX_rightAligned[WC_MAX_CURVE_SIZE] = {1};
+  byte wc_QY_rightAligned[WC_MAX_CURVE_SIZE] = {1};
+  byte wc_D_rightAligned[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_r[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_s[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_k[WC_MAX_CURVE_SIZE] = {0};
 
   word32 wc_D_len = 0;
-  word32 wc_QX_len = 0;
-  word32 wc_QY_len = 0;
   word32 wc_D_rightAligned_len = 0;
   word32 wc_QX_rightAligned_len = 0;
   word32 wc_QY_rightAligned_len = 0;
   word32 wc_r_len = 0;
   word32 wc_s_len = 0;
   word32 wc_k_len = 0;
+  int wc_curve_size = 0;
 
 
   mp_int wc_r_mpi;
@@ -647,7 +743,9 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
   word32 wc_signature_len = 0;
 
   wc_curve_id = wc_name_to_curve_id(ec->name);
-
+  if (wc_curve_id != ECC_CURVE_INVALID) {
+    wc_curve_size = wc_ecc_get_curve_size_from_id(wc_curve_id);
+  }
 
 
   if (DBG_CIPHER)
@@ -672,7 +770,7 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
       return rc;
     }
 
-  if (wc_curve_id != ECC_CURVE_INVALID && !(flags & PUBKEY_FLAG_RAW_FLAG)) {
+  if (wc_curve_id != ECC_CURVE_INVALID) {
     wolf = 1;
     ret = wc_InitRng(&rng);
     if (ret != 0) {
@@ -687,77 +785,18 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
 
 
     /* Allocate memory for the key */
-    wc_D_len = (word32)wc_ecc_get_curve_size_from_id(wc_curve_id);
-    wc_QX_len = wc_D_len;
-    wc_QY_len = wc_D_len;
+    wc_D_len = (word32)wc_curve_size;
     wc_D_rightAligned_len = wc_D_len;
     wc_QX_rightAligned_len = wc_D_len;
     wc_QY_rightAligned_len = wc_D_len;
 
-    wc_D_rightAligned = (byte *)XMALLOC(wc_D_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_D_rightAligned == NULL) {
-      rc = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      wc_FreeRng(&rng);
-      goto leave;
-    }
-    XMEMSET(wc_D_rightAligned, 0, wc_D_rightAligned_len);
-
-    wc_QX_rightAligned = (byte *)XMALLOC(wc_QX_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_QX_rightAligned == NULL) {
-      rc = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-    XMEMSET(wc_QX_rightAligned, 0, wc_QX_rightAligned_len);
-
-    wc_QY_rightAligned = (byte *)XMALLOC(wc_QY_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_QY_rightAligned == NULL) {
-      rc = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-    XMEMSET(wc_QY_rightAligned, 0, wc_QY_rightAligned_len);
-
     /* Get Curve Parameters from libgcrypt */
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_D,
-                                &wc_D_len, ec->d);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_D,
+                                WC_MAX_CURVE_SIZE, &wc_D_len, ec->d);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
       wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_QX,
-                                &wc_QX_len, ec->Q->x);
-    if (ret != 0) {
-      rc = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_QY,
-                                &wc_QY_len, ec->Q->y);
-    if (ret != 0) {
-      rc = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
@@ -806,23 +845,18 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
     /* LIBGCRYPT CODE -- END: */
 
   if (k != NULL) {
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_k,
-                                    &wc_k_len, k);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_k,
+                                    WC_MAX_CURVE_SIZE, &wc_k_len, k);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
       wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
   }
     /* Right align the key */
     /* libgcrypt wont extend to full length, so we need to do it manually */
     memcpy(wc_D_rightAligned + (wc_D_rightAligned_len - wc_D_len), wc_D, wc_D_len);
-    memcpy(wc_QX_rightAligned + (wc_QX_rightAligned_len - wc_QX_len), wc_QX, wc_QX_len);
-    memcpy(wc_QY_rightAligned + (wc_QY_rightAligned_len - wc_QY_len), wc_QY, wc_QY_len);
 
     /* Import the key into wolfSSL */
     ret = wc_ecc_import_unsigned(&wc_key, wc_QX_rightAligned,
@@ -832,18 +866,11 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
       wc_FreeRng(&rng);
-      XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
 
     /* Do not need these anymore */
-    XFREE(wc_D_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
   if (k != NULL) {
     ret = wc_ecc_sign_set_k(wc_k, wc_k_len, &wc_key);
     if (ret != 0) {
@@ -885,7 +912,6 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
                             &rng, &wc_key,
                             &wc_r_mpi, &wc_s_mpi);
     if (ret != 0) {
-      printf("wc_ecc_sign_hash_ex failed\n");
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
       wc_FreeRng(&rng);
@@ -893,79 +919,30 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
       mp_clear(&wc_s_mpi);
       goto leave;
     }
-
+    _gcry_free (wc_hash);
     wc_FreeRng(&rng); /* dont need this anymore */
-
-    /* Verify the signature */
-    ret = wc_ecc_verify_hash_ex(&wc_r_mpi, &wc_s_mpi,
-                                wc_hash, wc_hash_len,
-                                &is_valid_signature, &wc_key);
-    if (is_valid_signature == 0) { /* false */
-      printf("is_valid_signature: %d\n", is_valid_signature);
-      rc = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      mp_clear(&wc_r_mpi);
-      mp_clear(&wc_s_mpi);
-      goto leave;
-    }
-
     wc_ecc_free(&wc_key); /* dont need this anymore */
 
     /* convert r and s to libgcrypt mpi */
-    wc_r_len = (word32)mp_unsigned_bin_size(&wc_r_mpi);
-    wc_s_len = (word32)mp_unsigned_bin_size(&wc_s_mpi);
-
-    /* allocate memory for r and s */
-    wc_r = (byte *)XMALLOC(wc_r_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_r == NULL) {
-      rc = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      mp_clear(&wc_r_mpi);
-      mp_clear(&wc_s_mpi);
-      goto leave;
-    }
-    wc_s = (byte *)XMALLOC(wc_s_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_s == NULL) {
-      rc = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_r, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      mp_clear(&wc_r_mpi);
-      mp_clear(&wc_s_mpi);
-      goto leave;
-    }
-
-
-    ret = mp_to_unsigned_bin(&wc_r_mpi, wc_r);
+    ret = _wc_mpi_to_libgcrypt_mpi(&wc_r_mpi, r);
     if (ret != 0) {
-      rc = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_r, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_s, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+      rc = GPG_ERR_ENOMEM;
       mp_clear(&wc_r_mpi);
       mp_clear(&wc_s_mpi);
       goto leave;
     }
 
-    ret = mp_to_unsigned_bin(&wc_s_mpi, wc_s);
+    ret = _wc_mpi_to_libgcrypt_mpi(&wc_s_mpi, s);
     if (ret != 0) {
-      rc = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_r, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_s, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+      rc = GPG_ERR_ENOMEM;
       mp_clear(&wc_r_mpi);
       mp_clear(&wc_s_mpi);
       goto leave;
     }
 
-    /* convert r and s to libgcrypt mpi */
-    _gcry_mpi_scan(&r, GCRYMPI_FMT_USG, wc_r, wc_r_len, NULL);
-    _gcry_mpi_scan(&s, GCRYMPI_FMT_USG, wc_s, wc_s_len, NULL);
 
-    XFREE(wc_r, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(wc_s, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     mp_clear(&wc_r_mpi);
     mp_clear(&wc_s_mpi);
-
   }
   else {
   if (rc)
@@ -1095,11 +1072,11 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
     mpi_free (dr);
     if (!k_supplied)
         mpi_free (k);
-  }
+    if (hash != input)
+        mpi_free (hash);
+    mpi_free (hash_computed_internally);
 
-  if (hash != input)
-    mpi_free (hash);
-  mpi_free (hash_computed_internally);
+  }
 
   return rc;
 }
@@ -1126,14 +1103,14 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
   int wolf = 0;
   ecc_curve_id wc_curve_id = ECC_CURVE_INVALID; /* no curve id */
 
-  byte *wc_QX = NULL;
-  byte *wc_QY = NULL;
-  byte *wc_QX_rightAligned = NULL;
-  byte *wc_QY_rightAligned = NULL;
-  byte *wc_r = NULL;
-  byte *wc_s = NULL;
-  byte *wc_r_rightAligned = NULL;
-  byte *wc_s_rightAligned = NULL;
+  byte wc_QX[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_QY[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_QX_rightAligned[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_QY_rightAligned[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_r[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_s[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_r_rightAligned[WC_MAX_CURVE_SIZE] = {0};
+  byte wc_s_rightAligned[WC_MAX_CURVE_SIZE] = {0};
 
   word32 wc_QX_len = 0;
   word32 wc_QY_len = 0;
@@ -1184,7 +1161,11 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     }
 
   /* Some raw messages have issues with wolfSSL, so we use libgcrypt's native implementation */
-  if (wc_curve_id != ECC_CURVE_INVALID && !(flags & PUBKEY_FLAG_RAW_FLAG)) {
+  #if 0
+  if (0) {
+  #else
+  if (wc_curve_id != ECC_CURVE_INVALID) {
+  #endif
     wolf = 1;
     ret = wc_ecc_init(&wc_key);
     if (ret != 0) {
@@ -1200,74 +1181,29 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     wc_r_rightAligned_len = wc_QX_len;
     wc_s_rightAligned_len = wc_QX_len;
 
-    wc_QX_rightAligned = (byte *)XMALLOC(wc_QX_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_QX_rightAligned == NULL) {
-      err = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      goto leave;
-    }
-    XMEMSET(wc_QX_rightAligned, 0, wc_QX_rightAligned_len);
-
-    wc_QY_rightAligned = (byte *)XMALLOC(wc_QY_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_QY_rightAligned == NULL) {
-      err = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-    XMEMSET(wc_QY_rightAligned, 0, wc_QY_rightAligned_len);
 
     /* Get public key coordinates from libgcrypt */
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_QX, &wc_QX_len, ec->Q->x);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_QX, WC_MAX_CURVE_SIZE,
+                                &wc_QX_len, ec->Q->x);
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_QY, &wc_QY_len, ec->Q->y);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_QY, WC_MAX_CURVE_SIZE,
+                                &wc_QY_len, ec->Q->y);
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
     /* Right align the key coordinates */
-    memcpy(wc_QX_rightAligned + (wc_QX_rightAligned_len - wc_QX_len), wc_QX, wc_QX_len);
-    memcpy(wc_QY_rightAligned + (wc_QY_rightAligned_len - wc_QY_len), wc_QY, wc_QY_len);
-
-    /* Get the signature values from libgcrypt */
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_r, &wc_r_len, r);
-    if (ret != 0) {
-      err = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_s, &wc_s_len, s);
-    if (ret != 0) {
-      err = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-
-    /* Get the hash value */
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_hash, &wc_hash_len, hash);
-    if (ret != 0) {
-      err = GPG_ERR_BROKEN_PUBKEY;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
+    memcpy(wc_QX_rightAligned + (wc_QX_rightAligned_len - wc_QX_len),
+                wc_QX, wc_QX_len);
+    memcpy(wc_QY_rightAligned + (wc_QY_rightAligned_len - wc_QY_len),
+                wc_QY, wc_QY_len);
 
     /* Import the public key into wolfSSL */
     ret = wc_ecc_import_unsigned(&wc_key, wc_QX_rightAligned, wc_QY_rightAligned,
@@ -1275,8 +1211,6 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
@@ -1284,8 +1218,6 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
@@ -1294,8 +1226,6 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     if (ret != 0) {
       err = GPG_ERR_INTERNAL;
       wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
@@ -1304,64 +1234,31 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
       err = GPG_ERR_INTERNAL;
       wc_ecc_free(&wc_key);
       mp_clear(&wc_r_mpi);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
       goto leave;
     }
 
-    wc_r_rightAligned = (byte *)XMALLOC(wc_r_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_r_rightAligned == NULL) {
-      err = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      mp_clear(&wc_r_mpi);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-    XMEMSET(wc_r_rightAligned, 0, wc_r_rightAligned_len);
 
-    wc_s_rightAligned = (byte *)XMALLOC(wc_s_rightAligned_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (wc_s_rightAligned == NULL) {
-      err = GPG_ERR_ENOMEM;
-      wc_ecc_free(&wc_key);
-      mp_clear(&wc_r_mpi);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_r_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
-    }
-    XMEMSET(wc_s_rightAligned, 0, wc_s_rightAligned_len);
-
-    /* Right align the signature values */
-    memcpy(wc_r_rightAligned + (wc_r_rightAligned_len - wc_r_len), wc_r, wc_r_len);
-    memcpy(wc_s_rightAligned + (wc_s_rightAligned_len - wc_s_len), wc_s, wc_s_len);
-
-    /* Convert r and s to MP integers */
-    ret = mp_read_unsigned_bin(&wc_r_mpi, wc_r_rightAligned, wc_r_rightAligned_len);
+    ret = _libgcrypt_mpi_to_wc_mpi(r, &wc_r_mpi, wc_r_rightAligned_len);
     if (ret != 0) {
-      err = GPG_ERR_INTERNAL;
-      wc_ecc_free(&wc_key);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_r_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_s_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
+        err = GPG_ERR_INTERNAL;
+        wc_ecc_free(&wc_key);
+        goto leave;
     }
 
-    ret = mp_read_unsigned_bin(&wc_s_mpi, wc_s_rightAligned, wc_s_rightAligned_len);
+    ret = _libgcrypt_mpi_to_wc_mpi(s, &wc_s_mpi, wc_s_rightAligned_len);
     if (ret != 0) {
-      err = GPG_ERR_INTERNAL;
-      wc_ecc_free(&wc_key);
-      mp_clear(&wc_r_mpi);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_r_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_s_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      goto leave;
+        err = GPG_ERR_INTERNAL;
+        wc_ecc_free(&wc_key);
+        goto leave;
     }
 
-    XFREE(wc_r_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(wc_s_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    /* Get the hash value */
+    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_hash, &wc_hash_len, hash);
+    if (ret != 0) {
+      err = GPG_ERR_BROKEN_PUBKEY;
+      wc_ecc_free(&wc_key);
+      goto leave;
+    }
 
     /* Verify the signature using wolfSSL */
     ret = wc_ecc_verify_hash_ex(&wc_r_mpi, &wc_s_mpi,
@@ -1372,8 +1269,7 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
       wc_ecc_free(&wc_key);
       mp_clear(&wc_r_mpi);
       mp_clear(&wc_s_mpi);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+      _gcry_free(wc_hash);
       goto leave;
     }
     else if (ret != 0) {
@@ -1381,15 +1277,14 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
       wc_ecc_free(&wc_key);
       mp_clear(&wc_r_mpi);
       mp_clear(&wc_s_mpi);
-      XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-      XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+      _gcry_free(wc_hash);
       goto leave;
     }
 
+
     /* Cleanup */
+    _gcry_free(wc_hash);
     wc_ecc_free(&wc_key);
-    XFREE(wc_QX_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(wc_QY_rightAligned, NULL, DYNAMIC_TYPE_TMP_BUFFER);
   }
   else {
     /* Use libgcrypt's native implementation for verify if wolfSSL can't handle this curve */
@@ -1448,17 +1343,13 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     mpi_free (h2);
     mpi_free (h1);
     mpi_free (h);
-  }
-
-leave:
-  if (wolf != 1) {
     if (hash != input)
       mpi_free (hash);
     mpi_free (hash_computed_internally);
   }
+leave:
 
-  return err;
+return err;
 }
-
 
 #endif

--- a/cipher/ecc.c
+++ b/cipher/ecc.c
@@ -1960,7 +1960,7 @@ wc_check_is_nist_curve(const char *curve_name) {
 }
 
 
-static enum ecc_curve_id
+static int
 wc_name_to_curve_id(const char *curve_name)
 {
     if (curve_name == NULL)
@@ -1970,35 +1970,35 @@ wc_name_to_curve_id(const char *curve_name)
     if (strcmp(curve_name, "NIST P-192") == 0 ||
         strcmp(curve_name, "secp192r1") == 0 ||
         strcmp(curve_name, "nistp192") == 0) {
-      printf("wc_name_to_curve_id: NIST P-192\n");
+      // printf("wc_name_to_curve_id: NIST P-192\n");
       return ECC_SECP192R1;
     }
 
     if (strcmp(curve_name, "NIST P-224") == 0 ||
         strcmp(curve_name, "secp224r1") == 0 ||
         strcmp(curve_name, "nistp224") == 0) {
-      printf("wc_name_to_curve_id: NIST P-224\n");
+      // printf("wc_name_to_curve_id: NIST P-224\n");
       return ECC_SECP224R1;
     }
 
     if (strcmp(curve_name, "NIST P-256") == 0 ||
         strcmp(curve_name, "secp256r1") == 0 ||
         strcmp(curve_name, "nistp256") == 0) {
-      printf("wc_name_to_curve_id: NIST P-256\n");
+      // printf("wc_name_to_curve_id: NIST P-256\n");
       return ECC_SECP256R1;
     }
 
     if (strcmp(curve_name, "NIST P-384") == 0 ||
         strcmp(curve_name, "secp384r1") == 0 ||
         strcmp(curve_name, "nistp384") == 0) {
-      printf("wc_name_to_curve_id: NIST P-384\n");
+      // printf("wc_name_to_curve_id: NIST P-384\n");
       return ECC_SECP384R1;
     }
 
     if (strcmp(curve_name, "NIST P-521") == 0 ||
         strcmp(curve_name, "secp521r1") == 0 ||
         strcmp(curve_name, "nistp521") == 0) {
-      printf("wc_name_to_curve_id: NIST P-521\n");
+      // printf("wc_name_to_curve_id: NIST P-521\n");
       return ECC_SECP521R1;
     }
 

--- a/cipher/ecc.c
+++ b/cipher/ecc.c
@@ -1966,6 +1966,7 @@ wc_name_to_curve_id(const char *curve_name)
     if (curve_name == NULL)
         return ECC_CURVE_INVALID;
 
+    /* No P-192 for wolfcrypt fips */
     /* NIST curves - check for different naming conventions */
     if (strcmp(curve_name, "NIST P-192") == 0 ||
         strcmp(curve_name, "secp192r1") == 0 ||
@@ -2002,6 +2003,8 @@ wc_name_to_curve_id(const char *curve_name)
       return ECC_SECP521R1;
     }
 
+
+    /* Other curves not supported */
     #if 0
     /* Other SECP curves */
     if (strcmp(curve_name, "secp112r1") == 0)
@@ -2122,7 +2125,8 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
     wc_curve_id = wc_name_to_curve_id(ec->name);
 
     /* Get curve identifier from the curve parameters if present */
-    if (wc_curve_id != ECC_CURVE_INVALID) {
+    /* Cannot generate P-192 keys with wolfSSL FIPS */
+    if (wc_curve_id != ECC_CURVE_INVALID && wc_curve_id != ECC_SECP192R1) {
       /* Init RNG */
       ret =  wc_InitRng(&rng);
       if (ret != 0) {

--- a/cipher/ecc.c
+++ b/cipher/ecc.c
@@ -2240,53 +2240,11 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
         rc = GPG_ERR_BROKEN_PUBKEY;
         goto leave;
       }
-      #if 0
-      ret = mp_read_unsigned_bin(wc_key.pubkey.x, wc_X, wc_X_len);
-      if (ret != 0) {
-        XFREE(wc_X, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_Y, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_Z, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_D, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_QX, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_QY, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        rc = GPG_ERR_BROKEN_PUBKEY;
-        goto leave;
-      }
-
-      ret = mp_read_unsigned_bin(wc_key.pubkey.y, wc_Y, wc_Y_len);
-      if (ret != 0) {
-        XFREE(wc_X, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_Y, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_Z, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_D, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_QX, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_QY, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        rc = GPG_ERR_BROKEN_PUBKEY;
-        goto leave;
-      }
-
-      ret = mp_read_unsigned_bin(wc_key.pubkey.z, wc_Z, wc_Z_len);
-      if (ret != 0) {
-        XFREE(wc_X, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_Y, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_Z, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_D, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_QX, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(wc_QY, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        rc = GPG_ERR_BROKEN_PUBKEY;
-        goto leave;
-      }
-      #endif
 
       /* Convert to libgcrypt format */
       _gcry_mpi_scan(&ec->d, GCRYMPI_FMT_USG, wc_D, wc_D_len, NULL);
       _gcry_mpi_scan(&Qx, GCRYMPI_FMT_USG, wc_QX, wc_QX_len, NULL);
       _gcry_mpi_scan(&Qy, GCRYMPI_FMT_USG, wc_QY, wc_QY_len, NULL);
-      #if 0
-      _gcry_mpi_scan(&ec->Q->x, GCRYMPI_FMT_USG, wc_X, wc_X_len, NULL);
-      _gcry_mpi_scan(&ec->Q->y, GCRYMPI_FMT_USG, wc_Y, wc_Y_len, NULL);
-      _gcry_mpi_scan(&ec->Q->z, GCRYMPI_FMT_USG, wc_Z, wc_Z_len, NULL);
-      #endif
 
       /* Free the temporary buffers */
       XFREE(wc_X, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/tests/benchmark.c
+++ b/tests/benchmark.c
@@ -1610,7 +1610,6 @@ ecc_bench (int iterations, int print_header)
       fflush (stdout);
 
       if (p_size == 521) {
-        printf("521 bit key\n");
         x = gcry_mpi_new (512);
         gcry_mpi_randomize (x, 512, GCRY_WEAK_RANDOM);
       }

--- a/tests/benchmark.c
+++ b/tests/benchmark.c
@@ -1609,8 +1609,15 @@ ecc_bench (int iterations, int print_header)
       printf ("     %s", elapsed_time (1));
       fflush (stdout);
 
-      x = gcry_mpi_new (p_size);
-      gcry_mpi_randomize (x, p_size, GCRY_WEAK_RANDOM);
+      if (p_size == 521) {
+        printf("521 bit key\n");
+        x = gcry_mpi_new (512);
+        gcry_mpi_randomize (x, 512, GCRY_WEAK_RANDOM);
+      }
+      else {
+        x = gcry_mpi_new (p_size);
+        gcry_mpi_randomize (x, p_size, GCRY_WEAK_RANDOM);
+      }
       if (is_ed25519)
         err = gcry_sexp_build (&data, NULL,
                                "(data (flags eddsa)(hash-algo sha512)"


### PR DESCRIPTION
Adds ability to use ECDSA from wolfssl. Key gen for P-224 - 521, and then keychecking for P-192 - 521 curves.

Also fixes API usage issue in benchmark.c

According to section 6.3 `Cryptographic Functions` https://www.gnupg.org/documentation/manuals/gcrypt.pdf

```
For DSA the input data is expected in this format:
(data
(flags raw)
(value mpi ))
Here, the data to be signed is directly given as an MPI. It is expect that this MPI
is the hash value. For the standard DSA, using a MPI is not a problem in regard to
leading zeroes because the hash value is directly used as an MPI. For better standard
conformance it would be better to explicitly use a memory string (like with pkcs1)
but that is currently not supported. However, for deterministic DSA as specified in
RFC6979 this can’t be used. Instead the following input is expecte
```

Originally the benchmark would pass/generate a hash size of 521 bits, There is no Hash that matches this so it is corrected to be 512. 