### PR TITLE
initial compiler warning error fixed via correcting type cast

### DIFF
--- a/cipher/cipher-ccm.c
+++ b/cipher/cipher-ccm.c
@@ -439,14 +439,14 @@ _wc_cipher_aes_ccm_close(gcry_cipher_hd_t c)
 
   wc_AesFree(aesCcmEnc);
   wc_AesFree(aesCcmDec);
+
+  return GPG_ERR_NO_ERROR;
 }
 
 gcry_err_code_t
 _wc_cipher_aes_ccm_reset(gcry_cipher_hd_t c)
 {
-  int ret;
   Aes *aesCcmEnc = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_enc);
-  Aes *aesCcmDec = &(((RIJNDAEL_context *)(c->context.c))->wc_aes_dec);
   unsigned int marks_key, marks_allow_weak_key;
   byte key[aesCcmEnc->keylen];
   size_t keylen = aesCcmEnc->keylen;
@@ -680,7 +680,7 @@ _wc_cipher_aes_ccm_encrypt (gcry_cipher_hd_t c, unsigned char *outbuf,
 
   ret = wc_AesCcmEncrypt(aesCcm, wc_c->cryptbuf,
                          wc_c->databuf, wc_c->databuf_len,
-                         aesCcm->reg, aesCcm->nonceSz,
+                         (byte *)aesCcm->reg, aesCcm->nonceSz,
                          wc_c->authtag, wc_c->authtag_len,
                          aadbuf, wc_c->aadbuf_len);
   if (ret != 0)
@@ -719,7 +719,7 @@ _wc_cipher_aes_ccm_decrypt (gcry_cipher_hd_t c, unsigned char *outbuf,
 
   ret = wc_AesCcmDecrypt(aesCcmDec, wc_c->cryptbuf,
                          wc_c->databuf, wc_c->databuf_len,
-                         aesCcmDec->reg, aesCcmDec->nonceSz,
+                         (byte *)aesCcmDec->reg, aesCcmDec->nonceSz,
                          wc_c->authtag, wc_c->authtag_len,
                          aadbuf, wc_c->aadbuf_len);
 
@@ -728,7 +728,7 @@ _wc_cipher_aes_ccm_decrypt (gcry_cipher_hd_t c, unsigned char *outbuf,
       /* Get the authtag by encrypting the plaintext again */
       ret = wc_AesCcmEncrypt(aesCcmEnc, wc_c->databuf,
                              wc_c->cryptbuf, wc_c->databuf_len,
-                             aesCcmEnc->reg, aesCcmEnc->nonceSz,
+                             (byte *)aesCcmEnc->reg, aesCcmEnc->nonceSz,
                              wc_c->authtag, wc_c->authtag_len,
                              aadbuf, wc_c->aadbuf_len);
   }

--- a/cipher/ecc-ecdsa.c
+++ b/cipher/ecc-ecdsa.c
@@ -367,223 +367,7 @@ wc_name_to_curve_id(const char *curve_name)
     return ECC_CURVE_INVALID;
 }
 
-/*
- * Convert libgcrypt hash algorithm ID to WolfSSL hash type
- * Returns the WolfSSL hash type or WC_HASH_TYPE_NONE on error
- */
-static int
-_libgcrypt_to_wc_hash(int gcry_hash_algo)
-{
-  switch (gcry_hash_algo)
-  {
-    case GCRY_MD_MD5:             /* 1 */
-      return WC_HASH_TYPE_MD5;
 
-    case GCRY_MD_SHA1:            /* 2 */
-      return WC_HASH_TYPE_SHA;
-
-    case GCRY_MD_SHA224:          /* 11 */
-      return WC_HASH_TYPE_SHA224;
-
-    case GCRY_MD_SHA256:          /* 8 */
-      return WC_HASH_TYPE_SHA256;
-
-    case GCRY_MD_SHA384:          /* 9 */
-      return WC_HASH_TYPE_SHA384;
-
-    case GCRY_MD_SHA512:          /* 10 */
-      return WC_HASH_TYPE_SHA512;
-
-    case GCRY_MD_SHA3_224:        /* 312 */
-      return WC_HASH_TYPE_SHA3_224;
-
-    case GCRY_MD_SHA3_256:        /* 313 */
-      return WC_HASH_TYPE_SHA3_256;
-
-    case GCRY_MD_SHA3_384:        /* 314 */
-      return WC_HASH_TYPE_SHA3_384;
-
-    case GCRY_MD_SHA3_512:        /* 315 */
-      return WC_HASH_TYPE_SHA3_512;
-
-#ifndef WOLFSSL_NOSHA512_224
-    case GCRY_MD_SHA512_224:      /* 328 */
-      return WC_HASH_TYPE_SHA512_224;
-#endif
-#ifndef WOLFSSL_NOSHA512_256
-    case GCRY_MD_SHA512_256:      /* 327 */
-      return WC_HASH_TYPE_SHA512_256;
-#endif
-
-    default:
-      //printf("Unsupported hash algorithm: %d\n", gcry_hash_algo);
-      return WC_HASH_TYPE_NONE;
-  }
-}
-
-
-/* will do the digest of the data and return the digest */
-static int
-_wc_create_digest(byte* data, size_t dataLen, byte* digest, size_t digestLen, int hashType)
-{
-
-  int ret = 0;
-
-  switch (hashType) {
-    case WC_HASH_TYPE_SHA:
-    {
-      wc_Sha sha;
-      ret = wc_InitSha(&sha);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_ShaUpdate(&sha, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_ShaFinal(&sha, digest);
-      break;
-    }
-    case WC_HASH_TYPE_SHA224:
-    {
-      wc_Sha224 sha224;
-      ret = wc_InitSha224(&sha224);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha224Update(&sha224, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha224Final(&sha224, digest);
-      break;
-    }
-    case WC_HASH_TYPE_SHA256:
-    {
-      wc_Sha256 sha256;
-      ret = wc_InitSha256(&sha256);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha256Update(&sha256, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha256Final(&sha256, digest);
-      break;
-    }
-    case WC_HASH_TYPE_SHA384:
-    {
-      wc_Sha384 sha384;
-      ret = wc_InitSha384(&sha384);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha384Update(&sha384, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha384Final(&sha384, digest);
-      break;
-    }
-#ifndef WOLFSSL_NOSHA512_224
-    case WC_HASH_TYPE_SHA512_224:
-    {
-      wc_Sha512_224 sha512_224;
-      ret = wc_InitSha512_224(&sha512_224);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha512_224Update(&sha512_224, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha512_224Final(&sha512_224, digest);
-      break;
-    }
-#endif
-#ifndef WOLFSSL_NOSHA512_256
-    case WC_HASH_TYPE_SHA512_256:
-    {
-      wc_Sha512_256 sha512_256;
-      ret = wc_InitSha512_256(&sha512_256);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha512_256Update(&sha512_256, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha512_256Final(&sha512_256, digest);
-      break;
-    }
-#endif
-    case WC_HASH_TYPE_SHA512:
-    {
-      wc_Sha512 sha512;
-      ret = wc_InitSha512(&sha512);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha512Update(&sha512, data, dataLen);
-      if (ret != 0) {
-        return ret;
-      }
-      ret = wc_Sha512Final(&sha512, digest);
-      break;
-    }
-    default:
-      printf("Unsupported hash algorithm: %d\n", hashType);
-      return -1;
-  }
-  return ret;
-}
-
-
-
-/*
- * Get the hash length (in bytes) for a given libgcrypt hash algorithm
- * Returns the length in bytes or 0 on error
- */
-static int
-_libgcrypt_hash_length(int gcry_hash_algo)
-{
-  /* Return appropriate hash length in bytes */
-  switch (gcry_hash_algo)
-  {
-    case GCRY_MD_MD2:             /* 5 */
-    case GCRY_MD_MD4:             /* 301 */
-    case GCRY_MD_MD5:             /* 1 */
-    case GCRY_MD_SHAKE128:        /* 316 */
-      return 16;                  /* 128 bits = 16 bytes */
-
-    case GCRY_MD_SHA1:            /* 2 */
-      return 20;                  /* 160 bits = 20 bytes */
-
-    case GCRY_MD_SHA224:          /* 11 */
-    case GCRY_MD_SHA512_224:      /* 328 */
-    case GCRY_MD_SHA3_224:        /* 312 */
-      return 28;                  /* 224 bits = 28 bytes */
-
-    case GCRY_MD_SHA256:          /* 8 */
-    case GCRY_MD_SHA512_256:      /* 327 */
-    case GCRY_MD_SHA3_256:        /* 313 */
-    case GCRY_MD_SHAKE256:        /* 317 */
-      return 32;                  /* 256 bits = 32 bytes */
-
-    case GCRY_MD_SHA384:          /* 9 */
-    case GCRY_MD_SHA3_384:        /* 314 */
-      return 48;                  /* 384 bits = 48 bytes */
-
-    case GCRY_MD_SHA512:          /* 10 */
-    case GCRY_MD_SHA3_512:        /* 315 */
-      return 64;                  /* 512 bits = 64 bytes */
-
-    default:
-      //printf("Unsupported hash algorithm: %d\n", gcry_hash_algo);
-      return 0;
-  }
-}
 
 /* Way to convert wolfSSL mpi to libgcrypt mpi */
 static int
@@ -717,19 +501,11 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
   ecc_curve_id wc_curve_id = ECC_CURVE_INVALID; /* no curve id */
 
   byte wc_D[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_QX_rightAligned[WC_MAX_CURVE_SIZE] = {1};
-  byte wc_QY_rightAligned[WC_MAX_CURVE_SIZE] = {1};
   byte wc_D_rightAligned[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_r[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_s[WC_MAX_CURVE_SIZE] = {0};
   byte wc_k[WC_MAX_CURVE_SIZE] = {0};
 
   word32 wc_D_len = 0;
   word32 wc_D_rightAligned_len = 0;
-  word32 wc_QX_rightAligned_len = 0;
-  word32 wc_QY_rightAligned_len = 0;
-  word32 wc_r_len = 0;
-  word32 wc_s_len = 0;
   word32 wc_k_len = 0;
   int wc_curve_size = 0;
 
@@ -737,17 +513,11 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
   mp_int wc_r_mpi;
   mp_int wc_s_mpi;
 
-  int is_valid_signature = 0;
-  byte k_is_null[1] = {0};
-
   /* wc_hash */
   /* will grab from libgcrypt */
   byte* wc_hash = NULL;
   word32 wc_hash_len = 0;
 
-  /* Signature from wolfSSL */
-  byte* wc_signature = NULL;
-  word32 wc_signature_len = 0;
 
   wc_curve_id = wc_name_to_curve_id(ec->name);
   if (wc_curve_id != ECC_CURVE_INVALID) {
@@ -798,12 +568,10 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
     /* Allocate memory for the key */
     wc_D_len = (word32)wc_curve_size;
     wc_D_rightAligned_len = wc_D_len;
-    wc_QX_rightAligned_len = wc_D_len;
-    wc_QY_rightAligned_len = wc_D_len;
 
     /* Get Curve Parameters from libgcrypt */
-    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_D,
-                                WC_MAX_CURVE_SIZE, &wc_D_len, ec->d);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *)&wc_D,
+                                WC_MAX_CURVE_SIZE, (size_t *)&wc_D_len, ec->d);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
@@ -856,8 +624,8 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
     /* LIBGCRYPT CODE -- END: */
 
   if (k != NULL) {
-    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_k,
-                                    WC_MAX_CURVE_SIZE, &wc_k_len, k);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *)&wc_k,
+                                    WC_MAX_CURVE_SIZE, (size_t *)&wc_k_len, k);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
@@ -890,8 +658,8 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input, gcry_mpi_t k_supplied, mpi_ec_t ec,
     }
   }
     /* Get the hash */
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_hash,
-                                &wc_hash_len, hash);
+    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, (unsigned char **)&wc_hash,
+                                (size_t *)&wc_hash_len, hash);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
@@ -1110,24 +878,17 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
   /* wolfSSL declarations */
   int ret;
   ecc_key wc_key;
-  int wolf = 0;
   ecc_curve_id wc_curve_id = ECC_CURVE_INVALID; /* no curve id */
 
   byte wc_QX[WC_MAX_CURVE_SIZE] = {0};
   byte wc_QY[WC_MAX_CURVE_SIZE] = {0};
   byte wc_QX_rightAligned[WC_MAX_CURVE_SIZE] = {0};
   byte wc_QY_rightAligned[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_r[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_s[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_r_rightAligned[WC_MAX_CURVE_SIZE] = {0};
-  byte wc_s_rightAligned[WC_MAX_CURVE_SIZE] = {0};
 
   word32 wc_QX_len = 0;
   word32 wc_QY_len = 0;
   word32 wc_QX_rightAligned_len = 0;
   word32 wc_QY_rightAligned_len = 0;
-  word32 wc_r_len = 0;
-  word32 wc_s_len = 0;
   word32 wc_r_rightAligned_len = 0;
   word32 wc_s_rightAligned_len = 0;
 
@@ -1174,7 +935,6 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     }
 
   if (wc_curve_id != ECC_CURVE_INVALID) {
-    wolf = 1;
     ret = wc_ecc_init(&wc_key);
     if (ret != 0) {
       err = GPG_ERR_INTERNAL;
@@ -1191,16 +951,16 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
 
 
     /* Get public key coordinates from libgcrypt */
-    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_QX, WC_MAX_CURVE_SIZE,
-                                &wc_QX_len, ec->Q->x);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *)&wc_QX, WC_MAX_CURVE_SIZE,
+                                (size_t *)&wc_QX_len, ec->Q->x);
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
       goto leave;
     }
 
-    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, &wc_QY, WC_MAX_CURVE_SIZE,
-                                &wc_QY_len, ec->Q->y);
+    ret = _gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *)&wc_QY, WC_MAX_CURVE_SIZE,
+                                (size_t *)&wc_QY_len, ec->Q->y);
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
@@ -1261,7 +1021,8 @@ _gcry_ecc_ecdsa_verify (gcry_mpi_t input, mpi_ec_t ec,
     }
 
     /* Get the hash value */
-    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_hash, &wc_hash_len, hash);
+    ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, (unsigned char **)&wc_hash,
+                                (size_t *)&wc_hash_len, hash);
     if (ret != 0) {
       err = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);

--- a/cipher/ecc.c
+++ b/cipher/ecc.c
@@ -993,7 +993,7 @@ ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
     {
       /* EdDSA requires the public key.  */
     #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #pragma message "No ECC for EDDSA sign in FIPS mode with wolfssl"
+      /* No ECC for EDDSA sign in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       rc = _gcry_ecc_eddsa_sign (data, ec, sig_r, sig_s, &ctx);
@@ -1005,7 +1005,7 @@ ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   else if ((ctx.flags & PUBKEY_FLAG_GOST))
     {
     #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #pragma message "No ECC for GOST sign in FIPS mode with wolfssl"
+      /* No ECC for GOST sign in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       rc = _gcry_ecc_gost_sign (data, ec, sig_r, sig_s);
@@ -1017,7 +1017,7 @@ ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   else if ((ctx.flags & PUBKEY_FLAG_SM2))
     {
     #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #pragma message "No ECC for SM2 sign in FIPS mode with wolfssl"
+      /* No ECC for SM2 sign in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       rc = _gcry_ecc_sm2_sign (data, ec, sig_r, sig_s,
@@ -1151,7 +1151,7 @@ ecc_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t s_keyparms)
   if ((sigflags & PUBKEY_FLAG_EDDSA))
     {
 #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #pragma message "No ECC for EDDSA verify in FIPS mode with wolfssl"
+      /* No ECC for EDDSA verify in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
 #else
       rc = _gcry_ecc_eddsa_verify (data, ec, sig_r, sig_s, &ctx);
@@ -1160,7 +1160,7 @@ ecc_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t s_keyparms)
   else if ((sigflags & PUBKEY_FLAG_GOST))
     {
 #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #pragma message "No ECC for GOST verify in FIPS mode with wolfssl"
+      /* No ECC for GOST verify in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
 #else
       rc = _gcry_ecc_gost_verify (data, ec, sig_r, sig_s);
@@ -1169,7 +1169,7 @@ ecc_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t s_keyparms)
   else if ((sigflags & PUBKEY_FLAG_SM2))
     {
 #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #pragma message "No ECC for SM2 verify in FIPS mode with wolfssl"
+      /* No ECC for SM2 verify in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
 #else
       rc = _gcry_ecc_sm2_verify (data, ec, sig_r, sig_s);
@@ -1242,7 +1242,7 @@ ecc_encrypt_raw (gcry_sexp_t *r_ciph, gcry_sexp_t s_data, gcry_sexp_t keyparms)
    * Extract the key.
    */
   #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-  #pragma message "No ECC encrypt raw in FIPS mode with wolfssl"
+  /* No ECC encrypt raw in FIPS mode with wolfssl */
   rc = GPG_ERR_NOT_SUPPORTED;
   #else
   rc = _gcry_mpi_ec_internal_new (&ec, &flags, "ecc_encrypt", keyparms, NULL);
@@ -2140,7 +2140,7 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
       || (ec->model == MPI_EC_EDWARDS &&
       ec->dialect == ECC_DIALECT_SAFECURVE)) {
     #ifdef ENABLED_WOLFSSL_FIPS
-    #pragma message "No ECC for EDDSA generate in FIPS mode with wolfssl"
+    /* No ECC for EDDSA generate in FIPS mode with wolfssl */
     rc = GPG_ERR_NOT_SUPPORTED;
     #else
     rc = _gcry_ecc_eddsa_genkey (ec, flags);
@@ -2148,7 +2148,7 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
   }
   else if (ec->model == MPI_EC_MONTGOMERY) {
     #ifdef ENABLED_WOLFSSL_FIPS
-    #pragma message "No ECC for montgomery generate in FIPS mode with wolfssl"
+    /* No ECC for montgomery generate in FIPS mode with wolfssl */
     rc = GPG_ERR_NOT_SUPPORTED;
     #else
     rc = nist_generate_key(ec, flags, &Qx, NULL);
@@ -2302,7 +2302,7 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
     else {
       /* Non-NIST curve */
       #ifdef ENABLED_WOLFSSL_FIPS
-      #pragma message "No ECC for non-NIST curve generate in FIPS mode with wolfssl"
+      /* No ECC for non-NIST curve generate in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
       #else
       rc = nist_generate_key (ec, flags, &Qx, &Qy);
@@ -2620,7 +2620,7 @@ wc_ecc_check_secret_key (gcry_sexp_t keyparms)
   }
   else {
     #ifdef ENABLED_WOLFSSL_FIPS
-    #pragma message "ECC check secret key for NIST Curves only in FIPS mode with wolfssl"
+    /* ECC check secret key for NIST Curves only in FIPS mode with wolfssl */
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       if (check_secret_key (ec, flags)) {

--- a/cipher/ecc.c
+++ b/cipher/ecc.c
@@ -201,9 +201,13 @@ static void *progress_cb_data;
 
 
 /* Local prototypes. */
+#ifndef ENABLED_WOLFSSL_FIPS
 static void test_keys (mpi_ec_t ec, unsigned int nbits);
+#endif
 static int test_keys_fips (gcry_sexp_t skey);
+#ifndef ENABLED_WOLFSSL_FIPS
 static void test_ecdh_only_keys (mpi_ec_t ec, unsigned int nbits, int flags);
+#endif
 static unsigned int ecc_get_nbits (gcry_sexp_t parms);
 
 
@@ -225,7 +229,7 @@ _gcry_register_pk_ecc_progress (void (*cb) (void *, const char *,
 /*     progress_cb (progress_cb_data, "pk_ecc", c, 0, 0); */
 /* } */
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 
 /**
  * nist_generate_key - Standard version of the ECC key generation.
@@ -405,6 +409,7 @@ test_keys (mpi_ec_t ec, unsigned int nbits)
   mpi_free (c);
   mpi_free (test);
 }
+#endif
 
 /* We should get here only with the NIST curves as they are the only ones
  * having the fips bit set in ecc_domain_parms_t struct so this is slightly
@@ -529,7 +534,7 @@ leave:
   return result;
 }
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 static void
 test_ecdh_only_keys (mpi_ec_t ec, unsigned int nbits, int flags)
 {
@@ -710,13 +715,13 @@ check_secret_key (mpi_ec_t ec, int flags)
   point_free (&Q);
   return rc;
 }
-
+#endif
 
 
 /*********************************************
  **************  interface  ******************
  *********************************************/
-
+#ifndef HAVE_WOLFSSL
 static gcry_err_code_t
 ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
 {
@@ -884,8 +889,9 @@ ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
   sexp_release (curve_info);
   return rc;
 }
+#endif
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 static gcry_err_code_t
 ecc_check_secret_key (gcry_sexp_t keyparms)
 {
@@ -914,7 +920,7 @@ ecc_check_secret_key (gcry_sexp_t keyparms)
     log_debug ("ecc_testkey    => %s\n", gpg_strerror (rc));
   return rc;
 }
-
+#endif
 
 static gcry_err_code_t
 ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
@@ -1239,7 +1245,7 @@ ecc_encrypt_raw (gcry_sexp_t *r_ciph, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   /*
    * Extract the key.
    */
-  #ifdef HAVE_WOLFSSL && defined(ENABLED_WOLFSSL_FIPS)
+  #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
   #warning "No ECC encrypt raw in FIPS mode with wolfssl"
   rc = GPG_ERR_NOT_SUPPORTED;
   #else
@@ -1981,41 +1987,6 @@ _gcry_pk_ecc_get_sexp (gcry_sexp_t *r_sexp, int mode, mpi_ec_t ec)
 
 
 static int
-wc_check_is_nist_curve(const char *curve_name) {
-
-  if (curve_name == NULL) {
-    return 0; /* False */
-  }
-
-  if (strncmp(curve_name, "NIST P-192", 10) == 0 ||
-       strncmp(curve_name, "1.2.840.10045.3.1.1", 20) == 0 ||
-       strncmp(curve_name, "prime192v1", 11) == 0 ||
-       strncmp(curve_name, "secp192r1", 10) == 0 ||
-       strncmp(curve_name, "nistp192", 9) == 0 ||
-       strncmp(curve_name, "NIST P-224", 10) == 0 ||
-       strncmp(curve_name, "1.3.132.0.33", 13) == 0 ||
-       strncmp(curve_name, "secp224r1", 10) == 0 ||
-       strncmp(curve_name, "nistp224", 9) == 0 ||
-       strncmp(curve_name, "NIST P-256", 10) == 0 ||
-       strncmp(curve_name, "1.2.840.10045.3.1.7", 20) == 0 ||
-       strncmp(curve_name, "prime256v1", 11) == 0 ||
-       strncmp(curve_name, "secp256r1", 10) == 0 ||
-       strncmp(curve_name, "nistp256", 9) == 0 ||
-       strncmp(curve_name, "NIST P-384", 10) == 0 ||
-       strncmp(curve_name, "1.3.132.0.34", 13) == 0 ||
-       strncmp(curve_name, "secp384r1", 10) == 0 ||
-       strncmp(curve_name, "nistp384", 9) == 0 ||
-       strncmp(curve_name, "NIST P-521", 10) == 0 ||
-       strncmp(curve_name, "1.3.132.0.35", 13) == 0 ||
-       strncmp(curve_name, "secp521r1", 10) == 0 ||
-       strncmp(curve_name, "nistp521", 9) == 0 ) {
-      return 1; /* True */
-    }
-  return 0; /* False */
-}
-
-
-static int
 wc_name_to_curve_id(const char *curve_name)
 {
     if (curve_name == NULL)
@@ -2584,7 +2555,7 @@ wc_ecc_check_secret_key (gcry_sexp_t keyparms)
 
     /* Get Curve Parameters from libgcrypt */
     ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_D,
-                                &wc_D_len, ec->d);
+                                (size_t *)&wc_D_len, ec->d);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
@@ -2595,7 +2566,7 @@ wc_ecc_check_secret_key (gcry_sexp_t keyparms)
     }
 
     ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_QX,
-                                &wc_QX_len, ec->Q->x);
+                                (size_t *)&wc_QX_len, ec->Q->x);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);
@@ -2606,7 +2577,7 @@ wc_ecc_check_secret_key (gcry_sexp_t keyparms)
     }
 
     ret = _gcry_mpi_aprint(GCRYMPI_FMT_USG, &wc_QY,
-                                &wc_QY_len, ec->Q->y);
+                                (size_t *)&wc_QY_len, ec->Q->y);
     if (ret != 0) {
       rc = GPG_ERR_BROKEN_PUBKEY;
       wc_ecc_free(&wc_key);

--- a/cipher/ecc.c
+++ b/cipher/ecc.c
@@ -78,10 +78,6 @@
 #include <wolfssl/wolfcrypt/integer.h>
 #endif
 
-#ifdef ENABLED_WOLFSSL_FIPS
-#warning Work needed for FIPS version of wolfcrypt
-#endif
-
 static const char *ecc_names[] =
   {
     "ecc",
@@ -997,7 +993,7 @@ ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
     {
       /* EdDSA requires the public key.  */
     #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #warning "No ECC for EDDSA sign in FIPS mode with wolfssl"
+      #pragma message "No ECC for EDDSA sign in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       rc = _gcry_ecc_eddsa_sign (data, ec, sig_r, sig_s, &ctx);
@@ -1009,7 +1005,7 @@ ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   else if ((ctx.flags & PUBKEY_FLAG_GOST))
     {
     #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #warning "No ECC for GOST sign in FIPS mode with wolfssl"
+      #pragma message "No ECC for GOST sign in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       rc = _gcry_ecc_gost_sign (data, ec, sig_r, sig_s);
@@ -1021,7 +1017,7 @@ ecc_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   else if ((ctx.flags & PUBKEY_FLAG_SM2))
     {
     #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #warning "No ECC for SM2 sign in FIPS mode with wolfssl"
+      #pragma message "No ECC for SM2 sign in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       rc = _gcry_ecc_sm2_sign (data, ec, sig_r, sig_s,
@@ -1155,7 +1151,7 @@ ecc_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t s_keyparms)
   if ((sigflags & PUBKEY_FLAG_EDDSA))
     {
 #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #warning "No ECC for EDDSA verify in FIPS mode with wolfssl"
+      #pragma message "No ECC for EDDSA verify in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
 #else
       rc = _gcry_ecc_eddsa_verify (data, ec, sig_r, sig_s, &ctx);
@@ -1164,7 +1160,7 @@ ecc_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t s_keyparms)
   else if ((sigflags & PUBKEY_FLAG_GOST))
     {
 #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #warning "No ECC for GOST verify in FIPS mode with wolfssl"
+      #pragma message "No ECC for GOST verify in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
 #else
       rc = _gcry_ecc_gost_verify (data, ec, sig_r, sig_s);
@@ -1173,7 +1169,7 @@ ecc_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t s_keyparms)
   else if ((sigflags & PUBKEY_FLAG_SM2))
     {
 #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-      #warning "No ECC for SM2 verify in FIPS mode with wolfssl"
+      #pragma message "No ECC for SM2 verify in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
 #else
       rc = _gcry_ecc_sm2_verify (data, ec, sig_r, sig_s);
@@ -1246,7 +1242,7 @@ ecc_encrypt_raw (gcry_sexp_t *r_ciph, gcry_sexp_t s_data, gcry_sexp_t keyparms)
    * Extract the key.
    */
   #if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
-  #warning "No ECC encrypt raw in FIPS mode with wolfssl"
+  #pragma message "No ECC encrypt raw in FIPS mode with wolfssl"
   rc = GPG_ERR_NOT_SUPPORTED;
   #else
   rc = _gcry_mpi_ec_internal_new (&ec, &flags, "ecc_encrypt", keyparms, NULL);
@@ -2144,7 +2140,7 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
       || (ec->model == MPI_EC_EDWARDS &&
       ec->dialect == ECC_DIALECT_SAFECURVE)) {
     #ifdef ENABLED_WOLFSSL_FIPS
-    #warning "No ECC for EDDSA generate in FIPS mode with wolfssl"
+    #pragma message "No ECC for EDDSA generate in FIPS mode with wolfssl"
     rc = GPG_ERR_NOT_SUPPORTED;
     #else
     rc = _gcry_ecc_eddsa_genkey (ec, flags);
@@ -2152,7 +2148,7 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
   }
   else if (ec->model == MPI_EC_MONTGOMERY) {
     #ifdef ENABLED_WOLFSSL_FIPS
-    #warning "No ECC for montgomery generate in FIPS mode with wolfssl"
+    #pragma message "No ECC for montgomery generate in FIPS mode with wolfssl"
     rc = GPG_ERR_NOT_SUPPORTED;
     #else
     rc = nist_generate_key(ec, flags, &Qx, NULL);
@@ -2306,7 +2302,7 @@ wc_ecc_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
     else {
       /* Non-NIST curve */
       #ifdef ENABLED_WOLFSSL_FIPS
-      #warning "No ECC for non-NIST curve generate in FIPS mode with wolfssl"
+      #pragma message "No ECC for non-NIST curve generate in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
       #else
       rc = nist_generate_key (ec, flags, &Qx, &Qy);
@@ -2624,7 +2620,7 @@ wc_ecc_check_secret_key (gcry_sexp_t keyparms)
   }
   else {
     #ifdef ENABLED_WOLFSSL_FIPS
-    #warning "ECC check secret key for NIST Curves only in FIPS mode with wolfssl"
+    #pragma message "ECC check secret key for NIST Curves only in FIPS mode with wolfssl"
       rc = GPG_ERR_NOT_SUPPORTED;
     #else
       if (check_secret_key (ec, flags)) {

--- a/cipher/kdf.c
+++ b/cipher/kdf.c
@@ -34,7 +34,9 @@
 #endif
 
 #ifndef USE_BLAKE2
+#ifndef ENABLED_WOLFSSL_FIPS /* Shouldnt be using Blake anyways since its not in FIPs*/
 #warning "USE_BLAKE2 is not defined, need for Argon2"
+#endif
 #endif
 
 /* Transform a passphrase into a suitable key of length KEYSIZE and
@@ -405,7 +407,6 @@ beswap64_block (u64 *dst)
 #endif
 }
 
-
 static gpg_err_code_t
 argon2_fill_first_blocks (argon2_ctx_t a)
 {
@@ -492,9 +493,11 @@ argon2_fill_first_blocks (argon2_ctx_t a)
 #endif
       beswap64_block (&a->block[(i*a->lane_length+1)*ARGON2_WORDS_IN_BLOCK]);
     }
+  (void)iov;
   return 0;
 }
 
+#if defined(USE_BLAKE2)
 static gpg_err_code_t
 argon2_init (argon2_ctx_t a, unsigned int parallelism,
              unsigned int m_cost, unsigned int t_cost)
@@ -543,7 +546,7 @@ argon2_init (argon2_ctx_t a, unsigned int parallelism,
   a->thread_data = thread_data;
   return 0;
 }
-
+#endif
 
 static u64 fBlaMka (u64 x, u64 y)
 {
@@ -843,6 +846,7 @@ argon2_close (argon2_ctx_t a)
   xfree (a);
 }
 
+#if defined(USE_BLAKE2)
 static gpg_err_code_t
 argon2_open (gcry_kdf_hd_t *hd, int subalgo,
              const unsigned long *param, unsigned int paramlen,
@@ -920,6 +924,7 @@ argon2_open (gcry_kdf_hd_t *hd, int subalgo,
   *hd = (void *)a;
   return 0;
 }
+#endif
 
 typedef struct balloon_context *balloon_ctx_t;
 

--- a/cipher/keccak.c
+++ b/cipher/keccak.c
@@ -1099,6 +1099,7 @@ keccak_init (int algo, void *context, unsigned int flags)
 #endif
 }
 
+#ifndef HAVE_WOLFSSL
 static void
 sha3_224_init (void *context, unsigned int flags)
 {
@@ -1122,6 +1123,7 @@ sha3_512_init (void *context, unsigned int flags)
 {
   keccak_init (GCRY_MD_SHA3_512, context, flags);
 }
+#endif
 
 static void
 shake128_init (void *context, unsigned int flags)
@@ -1397,7 +1399,7 @@ _gcry_sha3_hash_buffers (void *outbuf, size_t nbytes, const gcry_buffer_t *iov,
     do_keccak_extract (&hd, outbuf, nbytes);
 }
 
-
+#ifndef HAVE_WOLFSSL
 static void
 _gcry_sha3_224_hash_buffers (void *outbuf, size_t nbytes,
 			     const gcry_buffer_t *iov, int iovcnt)
@@ -1429,6 +1431,7 @@ _gcry_sha3_512_hash_buffers (void *outbuf, size_t nbytes,
   _gcry_sha3_hash_buffers (outbuf, nbytes, iov, iovcnt,
 			   &_gcry_digest_spec_sha3_512);
 }
+#endif
 
 static void
 _gcry_shake128_hash_buffers (void *outbuf, size_t nbytes,
@@ -1445,7 +1448,6 @@ _gcry_shake256_hash_buffers (void *outbuf, size_t nbytes,
   _gcry_sha3_hash_buffers (outbuf, nbytes, iov, iovcnt,
 			   &_gcry_digest_spec_shake256);
 }
-
 
 static unsigned int
 cshake_input_n (KECCAK_CONTEXT *ctx, const void *n, unsigned int n_len)

--- a/cipher/kem.c
+++ b/cipher/kem.c
@@ -76,6 +76,7 @@ static const char *kem_names[] =
 
 
 /* Helper for sntrup761.  */
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 sntrup761_random (void *ctx, size_t length, uint8_t *dst)
 {
@@ -83,7 +84,7 @@ sntrup761_random (void *ctx, size_t length, uint8_t *dst)
 
   _gcry_randomize (dst, length, GCRY_STRONG_RANDOM);
 }
-
+#endif
 
 gcry_err_code_t
 _gcry_kem_keypair (int algo,

--- a/cipher/mac-cmac.c
+++ b/cipher/mac-cmac.c
@@ -96,7 +96,7 @@ cmac_open (gcry_mac_hd_t h)
   return 0;
 }
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 static void
 cmac_close (gcry_mac_hd_t h)
 {
@@ -140,7 +140,7 @@ cmac_verify (gcry_mac_hd_t h, const unsigned char *buf, size_t buflen)
 {
   return _gcry_cipher_cmac_check_tag (h->u.cmac.ctx, buf, buflen);
 }
-
+#endif
 
 static unsigned int
 cmac_get_maclen (int algo)
@@ -442,7 +442,7 @@ cmac_selftest (int algo, int extended, selftest_report_func_t report)
   return ec;
 }
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 static gcry_mac_spec_ops_t cmac_ops = {
   cmac_open,
   cmac_close,
@@ -457,6 +457,7 @@ static gcry_mac_spec_ops_t cmac_ops = {
   NULL,
   cmac_selftest
 };
+#endif
 
 #ifdef HAVE_WOLFSSL
 
@@ -477,7 +478,7 @@ wc_aes_cmac_close (gcry_mac_hd_t h)
 #if !defined(ENABLED_WOLFSSL_FIPS) || FIPS_VERSION3_GE(6,0,0)
   wc_CmacFree(&h->aesCmac);
 #else
-  wc_AesFree(&h->aesCmac);
+  wc_AesFree((Aes *)&h->aesCmac);
   wipememory(&h->aesCmac, sizeof(h->aesCmac));
 #endif
 
@@ -514,7 +515,7 @@ wc_aes_cmac_reset (gcry_mac_hd_t h)
 #if !defined(ENABLED_WOLFSSL_FIPS) || FIPS_VERSION3_GE(6,0,0)
   wc_CmacFree(&h->aesCmac);
 #else
-  wc_AesFree(&h->aesCmac);
+  wc_AesFree((Aes *)&h->aesCmac);
   wipememory(&h->aesCmac, sizeof(h->aesCmac));
 #endif
   return wc_InitCmac(&h->aesCmac, h->key, h->key_len, WC_CMAC_AES, NULL);
@@ -545,7 +546,7 @@ wc_aes_cmac_read (gcry_mac_hd_t h, unsigned char *outbuf, size_t * outlen)
     *outlen = h->authTag_len;
 
   if (h->authTagUpdated) {
-    wc_CmacFinal(&h->aesCmac, h->authTag, &h->authTag_len);
+    wc_CmacFinal(&h->aesCmac, h->authTag, (word32 *)&h->authTag_len);
     h->authTagUpdated = 0;
   }
   memcpy(outbuf, h->authTag, *outlen);
@@ -568,7 +569,7 @@ wc_aes_cmac_verify (gcry_mac_hd_t h, const unsigned char *buf, size_t buflen)
 
   }
 
-  wc_CmacFinal(&h->aesCmac, h->authTag, &h->authTag_len);
+  wc_CmacFinal(&h->aesCmac, h->authTag, (word32 *)&h->authTag_len);
   h->authTagUpdated = 0;
 
   return buf_eq_const(buf, h->authTag, buflen) ?

--- a/cipher/md.c
+++ b/cipher/md.c
@@ -1982,8 +1982,8 @@ _gcry_wc_md_enable (gcry_md_hd_t hd, int algorithm)
 {
 
   struct gcry_wc_md_context *wc = hd->ctx->wc_c;
-  GcryWcDigestEntry *entry;
-  GcryWcDigestEntry *last_list_entry;
+  GcryWcDigestEntry *entry = NULL;
+  GcryWcDigestEntry *last_list_entry = NULL;
   int rc;
 
   if (!digest_is_supported(algorithm))
@@ -2015,7 +2015,8 @@ _gcry_wc_md_enable (gcry_md_hd_t hd, int algorithm)
   rc = wc_HmacInit(&entry->hmac, NULL, 0);
   if (rc != 0) {
     free(entry);
-    last_list_entry->next = NULL;
+    if (last_list_entry)
+        last_list_entry->next = NULL;
     return GPG_ERR_GENERAL;
   }
 

--- a/cipher/rijndael.c
+++ b/cipher/rijndael.c
@@ -1550,38 +1550,11 @@ _gcry_aes_xts_crypt (void *context, unsigned char *tweak,
 
 #ifdef HAVE_WOLFSSL
 
-
-
-
-static void
-wc_prepare_decryption(RIJNDAEL_context *ctx)
-{
-  int ret;
-  if (ctx->decryption_prepared)
-    return;
-
-  ctx->decryption_prepared = 1;
-}
-
-
-static void
-wc_prepare_encryption(RIJNDAEL_context *ctx)
-{
-  int ret;
-  if (ctx->decryption_prepared == 0)
-    return;
-  ctx->decryption_prepared = 0;
-}
-
-
-
-
-
 static unsigned int
 wc_do_encrypt (const RIJNDAEL_context *ctx,
             unsigned char *bx, const unsigned char *ax)
 {
-  wc_AesEncryptDirect(&ctx->wc_aes_enc, bx, ax);
+  wc_AesEncryptDirect((Aes*)&ctx->wc_aes_enc, bx, ax);
   return WC_AES_BLOCK_SIZE;
 }
 
@@ -1591,14 +1564,9 @@ static unsigned int
 wc_do_decrypt (const RIJNDAEL_context *ctx, unsigned char *bx,
             const unsigned char *ax)
 {
-  wc_AesDecryptDirect(&ctx->wc_aes_dec, bx, ax);
+  wc_AesDecryptDirect((Aes*)&ctx->wc_aes_dec, bx, ax);
   return WC_AES_BLOCK_SIZE;
 }
-
-
-
-
-
 
 static void
 _wc_aes_ecb_enc (RIJNDAEL_context *ctx, unsigned char *dst,
@@ -1627,10 +1595,27 @@ _wc_aes_ecb_enc (RIJNDAEL_context *ctx, unsigned char *dst,
 }
 
 
+/* Wrapper functions for cipher spec interface (void* context) */
+static unsigned int
+wc_encrypt_wrapper(void *context, unsigned char *b, const unsigned char *a)
+{
+  return wc_do_encrypt((const RIJNDAEL_context *)context, b, a);
+}
 
+static unsigned int
+wc_decrypt_wrapper(void *context, unsigned char *b, const unsigned char *a)
+{
+  return wc_do_decrypt((const RIJNDAEL_context *)context, b, a);
+}
 
-
-
+/* Wrapper function for ECB bulk operations */
+static void
+wc_ecb_crypt_wrapper(void *context, void *outbuf_arg, const void *inbuf_arg,
+                     size_t nblocks, int encrypt)
+{
+  _wc_aes_ecb_enc((RIJNDAEL_context *)context, (unsigned char *)outbuf_arg,
+                  (const unsigned char *)inbuf_arg, nblocks, encrypt);
+}
 
 
 static void
@@ -1642,7 +1627,6 @@ _wc_aes_cbc_enc (void *context, unsigned char *iv,
   RIJNDAEL_context *ctx = (RIJNDAEL_context *)context;
   unsigned char *outbuf = outbuf_arg;
   const unsigned char *inbuf = inbuf_arg;
-  unsigned char tmpbuf[WC_AES_BLOCK_SIZE];
   unsigned char *ivp = iv;
   if (nblocks == 0)
     return;
@@ -1719,11 +1703,6 @@ _wc_aes_cbc_dec (void *context, unsigned char *iv,
 }
 
 
-
-
-
-
-
 static void
 _wc_aes_ofb_enc (void *context, unsigned char *iv,
                    void *outbuf_arg, const void *inbuf_arg,
@@ -1748,17 +1727,6 @@ _wc_aes_ofb_enc (void *context, unsigned char *iv,
 
   return;
 }
-
-
-
-
-
-
-
-
-
-
-
 
 
 static void
@@ -1787,86 +1755,6 @@ _wc_aes_ctr_enc (void *context, unsigned char *ctr,
 
 
 
-
-
-
-
-
-#if 1
-static size_t
-_wc_aes_gcm_crypt (gcry_cipher_hd_t c, void *outbuf_arg,
-                   const void *inbuf_arg, size_t nblocks, int encrypt)
-{
-  int ret = 0;
-  RIJNDAEL_context *ctx = (RIJNDAEL_context *)(&c->context.c);
-
-  /* Map function parameters properly */
-  byte* out = (byte*)outbuf_arg;
-  byte* in = (byte*)inbuf_arg;
-  word32 sz = nblocks * WC_AES_BLOCK_SIZE;
-
-  /* IV from libgcrypt */
-  //const byte *iv = c->u_mode.gcm.tagiv;
-  byte *iv = (byte*)c->u_mode.gcm.tagiv;
-  word32 ivSz = MAX_BLOCKSIZE; /* Standard GCM IV size */
-
-  /* Authentication tag */
-  //byte *authTag = c->u_mode.gcm.u_tag.tag;
-  byte *authTag = (byte*)c->u_mode.gcm.u_tag.tag;
-  word32 authTagSz = MAX_BLOCKSIZE; /* 16-byte auth tag */
-
-  /* AAD data */
-  byte *authIn = (byte*)c->u_mode.gcm.macbuf;
-  word32 authInSz = sizeof(c->u_mode.gcm.macbuf)*sizeof(byte);
-
-  if (encrypt) {
-    /* For encryption, authTag is output parameter */
-    ret = wc_AesGcmEncrypt(&ctx->wc_aes_enc, outbuf_arg, inbuf_arg, sz,
-                          iv, WC_AES_BLOCK_SIZE,
-                          authTag, authTagSz,
-                          authIn, authInSz);
-    if (ret != 0) {
-      printf("wc_AesGcmEncrypt failed: %d\n", ret);
-    }
-  }
-  else {
-    /* For decryption, authTag is input parameter for verification */
-    ret = wc_AesGcmDecrypt(&ctx->wc_aes_enc, outbuf_arg, inbuf_arg, sz,
-                          iv, WC_AES_BLOCK_SIZE,
-                          authTag, authTagSz,
-                          authIn, authInSz);
-    if (ret != 0) {
-      printf("wc_AesGcmDecrypt failed: %d\n", ret);
-    }
-  }
-}
-#endif
-
-
-
-
-
-static void
-wc_aes_setiv (void *context, const byte *iv, size_t ivlen)
-{
-  int ret = 0;
-  (void)ivlen;
-  RIJNDAEL_context *ctx = (RIJNDAEL_context *)context;
-  ret = wc_AesSetIV(&ctx->wc_aes_enc, iv);
-  if (ret != 0) {
-    printf("wc_AesSetIV failed: %d\n", ret);
-  }
-  ret = wc_AesSetIV(&ctx->wc_aes_dec, iv);
-  if (ret != 0) {
-    printf("wc_AesSetIV failed: %d\n", ret);
-  }
-
-  return;
-}
-
-
-
-
 /* Perform the key setup.  */
 static gcry_err_code_t
 wc_do_setkey (RIJNDAEL_context *ctx, const byte *key, const unsigned keylen,
@@ -1874,9 +1762,7 @@ wc_do_setkey (RIJNDAEL_context *ctx, const byte *key, const unsigned keylen,
 {
   static int initialized = 0;
   static const char *selftest_failed = 0;
-  void (*hw_setkey)(RIJNDAEL_context *ctx, const byte *key) = NULL;
   int rounds;
-  unsigned int KC;
   unsigned int hwfeatures;
 
   /* The on-the-fly self tests are only run in non-fips mode. In fips
@@ -1899,17 +1785,14 @@ wc_do_setkey (RIJNDAEL_context *ctx, const byte *key, const unsigned keylen,
   if( keylen == 128/8 )
     {
       rounds = 10;
-      KC = 4;
     }
   else if ( keylen == 192/8 )
     {
       rounds = 12;
-      KC = 6;
     }
   else if ( keylen == 256/8 )
     {
       rounds = 14;
-      KC = 8;
     }
   else
     return GPG_ERR_INV_KEYLEN;
@@ -1922,21 +1805,12 @@ wc_do_setkey (RIJNDAEL_context *ctx, const byte *key, const unsigned keylen,
   /* Setup default bulk encryption routines.  */
   memset (bulk_ops, 0, sizeof(*bulk_ops));
 
-  bulk_ops->ecb_crypt = _wc_aes_ecb_enc;
+  bulk_ops->ecb_crypt = wc_ecb_crypt_wrapper;
 
-  #if 0
   bulk_ops->cbc_enc = _wc_aes_cbc_enc;
   bulk_ops->cbc_dec = _wc_aes_cbc_dec;
   bulk_ops->ofb_enc = _wc_aes_ofb_enc;
   bulk_ops->ctr_enc = _wc_aes_ctr_enc;
-  bulk_ops->gcm_crypt = _wc_aes_gcm_crypt;
-  #else
-  bulk_ops->cbc_enc = _wc_aes_cbc_enc;
-  bulk_ops->cbc_dec = _wc_aes_cbc_dec;
-  bulk_ops->ofb_enc = _wc_aes_ofb_enc;
-  bulk_ops->ctr_enc = _wc_aes_ctr_enc;
-  //bulk_ops->gcm_crypt = _wc_aes_gcm_crypt;
-  #endif
 
 
 
@@ -1988,33 +1862,6 @@ wc_aes_setkey(void *context, const byte *key, const unsigned keylen,
     return ret;
   }
   ret = wc_do_setkey (ctx, key, keylen, bulk_ops);
-  return ret;
-}
-
-
-
-
-static unsigned int
-wc_aes_encrypt (void *context, byte *b, const byte *a)
-{
-  unsigned int ret = 0;
-
-  RIJNDAEL_context *ctx = context;
-
-  ret = ctx->encrypt_fn (ctx, b, a);
-
-  return ret;
-}
-
-static unsigned int
-wc_aes_decrypt (void *context, byte *b, const byte *a)
-{
-  unsigned int ret = 0;
-  RIJNDAEL_context *ctx = context;
-
-
-  ret = ctx->decrypt_fn (ctx, b, a);
-
   return ret;
 }
 
@@ -2458,7 +2305,7 @@ gcry_cipher_spec_t _gcry_cipher_spec_aes =
     GCRY_CIPHER_AES, {0, 1},
     "AES", rijndael_names, rijndael_oids, 16, 128,
     sizeof (RIJNDAEL_context),
-    wc_aes_setkey, wc_do_encrypt, wc_do_decrypt,
+    wc_aes_setkey, wc_encrypt_wrapper, wc_decrypt_wrapper,
     NULL, NULL,
     run_selftests
   };
@@ -2499,7 +2346,7 @@ gcry_cipher_spec_t _gcry_cipher_spec_aes192 =
     GCRY_CIPHER_AES192, {0, 1},
     "AES192", rijndael192_names, rijndael192_oids, 16, 192,
     sizeof (RIJNDAEL_context),
-    wc_aes_setkey, wc_do_encrypt, wc_do_decrypt,
+    wc_aes_setkey, wc_encrypt_wrapper, wc_decrypt_wrapper,
     NULL, NULL,
     run_selftests
   };
@@ -2540,7 +2387,7 @@ gcry_cipher_spec_t _gcry_cipher_spec_aes256 =
     GCRY_CIPHER_AES256, {0, 1},
     "AES256", rijndael256_names, rijndael256_oids, 16, 256,
     sizeof (RIJNDAEL_context),
-    wc_aes_setkey, wc_do_encrypt, wc_do_decrypt,
+    wc_aes_setkey, wc_encrypt_wrapper, wc_decrypt_wrapper,
     NULL, NULL,
     run_selftests
   };

--- a/cipher/rsa.c
+++ b/cipher/rsa.c
@@ -2187,11 +2187,11 @@ static int wc_gcrypt_CalcDX(mp_int* y, mp_int* x, mp_int* d)
 }
 #endif
 
-int wc_gcrypt_RsaPrivateKeyDecodeRaw(const byte* n, word32 nSz,
-        const byte* e, word32 eSz, const byte* d, word32 dSz,
-        const byte* u, word32 uSz, const byte* p, word32 pSz,
-        const byte* q, word32 qSz, const byte* dP, word32 dPSz,
-        const byte* dQ, word32 dQSz, RsaKey* key)
+int wc_gcrypt_RsaPrivateKeyDecodeRaw(byte* n, word32 nSz,
+        byte* e, word32 eSz, byte* d, word32 dSz,
+        byte* u, word32 uSz, byte* p, word32 pSz,
+        byte* q, word32 qSz, byte* dP, word32 dPSz,
+        byte* dQ, word32 dQSz, RsaKey* key)
 {
     int err = MP_OKAY;
     /* Needed for swapping p and q if p < q */
@@ -2561,29 +2561,6 @@ _libgcrypt_hash_length(int gcry_hash_algo)
 }
 
 
-/* Custom Compare function to compare data */
-static int
-_wc_gcrypt_compare_data(byte* expectedData, size_t expectedDataLen, byte* myData, size_t myDataLen)
-{
-
-  /* Calculate the offset, we need to do this because libgcrypt */
-  /* creates big buffers for the expected data, even if it does not fill */
-  /* the whole buffer. */
-
-  if (myDataLen > expectedDataLen) {
-    return 0;
-  }
-
-  /* Compare the data with offset*/
-  if (memcmp(myData, expectedData + (expectedDataLen - myDataLen), myDataLen) != 0) {
-    return 0;
-  }
-
-  return 1;
-}
-
-
-
 /* Function to pass libgcrypt key to wolfssl to get usable key for wolfssl rsa functions */
 /* Public key */
 static int
@@ -2621,11 +2598,11 @@ _gcryp_rsa_key_to_wolfssl_rsa_key(RSA_public_key *pk, RsaKey *wcRsaKey)
 
  leave:
   /* Wipe then free buffers */
-  if (myKey_mod_len != NULL) {
+  if (myKey_mod_len != 0) {
     wipememory(myKey_mod, myKey_mod_len);
     _gcry_free(myKey_mod);
   }
-  if (myKey_exp_len != NULL) {
+  if (myKey_exp_len != 0) {
     wipememory(myKey_exp, myKey_exp_len);
     _gcry_free(myKey_exp);
   }
@@ -2795,27 +2772,27 @@ if (ret != 0) {
 leave:
 
 /* Wipe then Free everything when done */
-if (myKey_mod_n_len != NULL) {
+if (myKey_mod_n_len != 0) {
   wipememory(myKey_mod_n, myKey_mod_n_len);
   _gcry_free(myKey_mod_n);
 }
-if (myKey_exp_e_len != NULL) {
+if (myKey_exp_e_len != 0) {
   wipememory(myKey_exp_e, myKey_exp_e_len);
   _gcry_free(myKey_exp_e);
 }
-if (myKey_exp_d_len != NULL) {
+if (myKey_exp_d_len != 0) {
   wipememory(myKey_exp_d, myKey_exp_d_len);
   _gcry_free(myKey_exp_d);
 }
-if (myKey_prime_p_len != NULL) {
+if (myKey_prime_p_len != 0) {
   wipememory(myKey_prime_p, myKey_prime_p_len);
   _gcry_free(myKey_prime_p);
 }
-if (myKey_prime_q_len != NULL) {
+if (myKey_prime_q_len != 0) {
   wipememory(myKey_prime_q, myKey_prime_q_len);
   _gcry_free(myKey_prime_q);
 }
-if (myKey_u_len != NULL) {
+if (myKey_u_len != 0) {
   wipememory(myKey_u, myKey_u_len);
   _gcry_free(myKey_u);
 }
@@ -2940,7 +2917,6 @@ wc_rsa_generate (const gcry_sexp_t genparms, gcry_sexp_t *r_skey)
 
   if (deriveparms || (flags & PUBKEY_FLAG_USE_X931))
     {
-      int swapped;
       if (fips_mode ())
         {
           sexp_release (deriveparms);
@@ -3203,7 +3179,7 @@ wc_rsa_encrypt (gcry_sexp_t *r_ciph, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   }
 
   rc = _gcry_mpi_print(GCRYMPI_FMT_USG, inputDataBlock, (size_t)sizeof(inputDataBlock),
-                       &inputDataBlockLen, data);
+                       (size_t *)&inputDataBlockLen, data);
   if (rc) {
     goto leave_wolf;
   }
@@ -3353,7 +3329,7 @@ wc_rsa_decrypt (gcry_sexp_t *r_plain, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   }
 
   rc = _gcry_mpi_print(GCRYMPI_FMT_USG, inputDataBlock, (size_t)sizeof(inputDataBlock),
-                       &inputDataBlockLen, data);
+                       (size_t *)&inputDataBlockLen, data);
   if (rc) {
     goto leave_wolf;
   }
@@ -3458,7 +3434,6 @@ wc_rsa_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
 
   /* wolfssl variables */
   int ret = 0;
-  int wolf = 0;
   RsaKey wcRsaKey;
 
   byte mySig[RSA_MAX_SIZE] = {0};
@@ -3476,7 +3451,7 @@ wc_rsa_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   unsigned int hashValue = 0;
 
   int isRaw = 1; /* Assume raw data for pss */
-  unsigned char *hash_value = NULL;
+  const char *hash_value = NULL;
   size_t hash_len = 0;
   gcry_sexp_t hash_param = NULL;
 
@@ -3544,11 +3519,11 @@ wc_rsa_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   }
 
   /* Shift the signature to be right aligned if needed */
-  shiftRight(mySig, &mySigLen, (nbits/8));
+  shiftRight(mySig, (word32 *)&mySigLen, (nbits/8));
 
   /* Expected data so we can compare */
   rc = _gcry_mpi_print(GCRYMPI_FMT_USG, expectedData, (size_t)sizeof(expectedData),
-                       &expectedDataLen, data);
+                       (size_t *)&expectedDataLen, data);
   if (rc) {
     goto leave_wolf;
   }
@@ -3626,11 +3601,12 @@ wc_rsa_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
     case PUBKEY_ENC_PKCS1_RAW:
     case PUBKEY_ENC_PKCS1:
     case PUBKEY_ENC_RAW:
+    case PUBKEY_ENC_OAEP:
       /* Allocate a buffer for the output */
       myDataLen = mySigLen;
 
       /* Perform raw RSA verification using wolfSSL's direct RSA function */
-      ret = wc_RsaDirect(mySig, mySigLen, myData, &myDataLen,
+      ret = wc_RsaDirect(mySig, mySigLen, myData, (word32 *)&myDataLen,
                         &wcRsaKey, RSA_PUBLIC_DECRYPT, NULL);
       if (ret < 0) {
           rc = GPG_ERR_BAD_SIGNATURE;
@@ -3642,6 +3618,9 @@ wc_rsa_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
       rc = mpi_cmp (result, data) ? GPG_ERR_BAD_SIGNATURE : 0;
 
     break;
+    default:
+      rc = GPG_ERR_BAD_SIGNATURE;
+      break;
   }
 
  leave_wolf:
@@ -3677,11 +3656,9 @@ wc_rsa_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   struct pk_encoding_ctx ctx;
   gcry_mpi_t data = NULL;
   RSA_secret_key sk = {NULL, NULL, NULL, NULL, NULL, NULL};
-  RSA_public_key pk;
   gcry_mpi_t sig = NULL;
   gcry_mpi_t result = NULL;
   unsigned int nbits = rsa_get_nbits (keyparms);
-  gcry_mpi_t myMpiSig = NULL;
 
   /* wolfssl variables */
 
@@ -3776,7 +3753,7 @@ wc_rsa_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   #endif
 
   /* Shift the input data to be right aligned if needed */
-  shiftRight(inputDataBlock, &inputDataBlockLen, (nbits/8));
+  shiftRight(inputDataBlock, (word32 *)&inputDataBlockLen, (nbits/8));
 
   #ifdef GCRY_WC_RSA_DEBUG
   printf("Input data block[%d]:\n", inputDataBlockLen);
@@ -3799,7 +3776,7 @@ wc_rsa_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
     case PUBKEY_ENC_OAEP:
       /* Comes prepadded and encoded/hashed */
       ret = wc_RsaDirect(inputDataBlock, inputDataBlockLen,
-                          outputSig, &outputSigLen,
+                          outputSig, (word32 *)&outputSigLen,
                           &wcRsaKey, RSA_PRIVATE_ENCRYPT,
                           &rng);
       if (ret < 0) {
@@ -3879,48 +3856,6 @@ wc_rsa_sign (gcry_sexp_t *r_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
   if (DBG_CIPHER)
     log_debug ("rsa_sign      => %s\n", gpg_strerror (rc));
   return rc;
-}
-
-static unsigned int
-wc_rsa_get_nbits (gcry_sexp_t parms)
-{
-  gcry_sexp_t l1;
-  gcry_mpi_t n;
-  unsigned int nbits;
-
-  l1 = sexp_find_token (parms, "n", 1);
-  if (!l1)
-    return 0; /* Parameter N not found.  */
-
-  n = sexp_nth_mpi (l1, 1, GCRYMPI_FMT_USG);
-  sexp_release (l1);
-  nbits = n? mpi_get_nbits (n) : 0;
-  _gcry_mpi_release (n);
-  return nbits;
-}
-
-static gpg_err_code_t
-wc_compute_keygrip (gcry_md_hd_t md, gcry_sexp_t keyparam)
-{
-  gcry_sexp_t l1;
-  const char *data;
-  size_t datalen;
-
-  l1 = sexp_find_token (keyparam, "n", 1);
-  if (!l1)
-    return GPG_ERR_NO_OBJ;
-
-  data = sexp_nth_data (l1, 1, &datalen);
-  if (!data)
-    {
-      sexp_release (l1);
-      return GPG_ERR_NO_OBJ;
-    }
-
-  _gcry_md_write (md, data, datalen);
-  sexp_release (l1);
-
-  return 0;
 }
 
 #endif

--- a/cipher/sha1.c
+++ b/cipher/sha1.c
@@ -628,6 +628,7 @@ sha1_final(void *context)
   _gcry_burn_stack (burn);
 }
 
+#ifndef HAVE_WOLFSSL
 static unsigned char *
 sha1_read( void *context )
 {
@@ -635,6 +636,7 @@ sha1_read( void *context )
 
   return hd->bctx.buf;
 }
+#endif
 
 /****************
  * Shortcut functions which puts the hash value of the supplied buffer iov

--- a/cipher/sha256.c
+++ b/cipher/sha256.c
@@ -691,7 +691,7 @@ wolfssl_sha224_transform_generic (void *ctx, const unsigned char *data, size_t n
   int ret = 0;
   SHA256_CONTEXT *hd = (SHA256_CONTEXT*)ctx;
 
-  ret = wc_Sha224Update(&hd->wc_sha2, data, 64 * nblks);
+  ret = wc_Sha224Update((wc_Sha224*)&hd->wc_sha2, data, 64 * nblks);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha224_transform_generic): wc_Sha224Update failed\n");
     printf("Return: %d\n", ret);
@@ -706,7 +706,7 @@ wolfssl_sha256_transform_generic (void *ctx, const unsigned char *data, size_t n
   int ret = 0;
   SHA256_CONTEXT *hd = (SHA256_CONTEXT*)ctx;
 
-  ret = wc_Sha256Update(&hd->wc_sha2, data, 64 * nblks);
+  ret = wc_Sha256Update((wc_Sha256*)&hd->wc_sha2, data, 64 * nblks);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha256_transform_generic): wc_Sha256Update failed\n");
     printf("Return: %d\n", ret);
@@ -748,43 +748,12 @@ wolfssl_sha256_common_init (SHA256_CONTEXT *hd)
 }
 
 static void
-wolfssl_sha256_digest_alloc(void* context, int algorithm)
-{
-  SHA256_CONTEXT *hd = context;
-
-  hd = (SHA256_CONTEXT*)XMALLOC(sizeof(SHA256_CONTEXT), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-  if (hd == NULL) {
-    printf("Error libgcrypt (wolfssl_sha256_init): malloc failed\n");
-    return;
-  }
-  return;
-}
-
-/* Deallocate a context for the wolfSSL digest context */
-/* to be used by libgcrypt */
-static void
-wolfssl_sha256_digest_free(void* context, int algorithm)
-{
-  SHA256_CONTEXT *hd = (SHA256_CONTEXT*)context;
-
-  if (hd != NULL) {
-    XFREE(hd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    hd = NULL;
-  }
-  else {
-    printf("Error libgcrypt (wolfssl_sha256_deinit): wc_sha2 is already NULL\n");
-  }
-
-  return;
-}
-
-static void
-wolfssl_sha224_init(void* context, int flags)
+wolfssl_sha224_init(void* context, unsigned int flags)
 {
   int ret = 0;
   SHA256_CONTEXT *hd = (SHA256_CONTEXT*)context;
   (void)flags;
-  ret = wc_InitSha224(&hd->wc_sha2);
+  ret = wc_InitSha224((wc_Sha224*)&hd->wc_sha2);
   if (ret != 0) {
     printf("Error libgcrypt (sha224_init): wc_InitSha224 failed\n");
     printf("Return: %d\n", ret);
@@ -795,13 +764,13 @@ wolfssl_sha224_init(void* context, int flags)
 
 
 static void
-wolfssl_sha256_init(void* context, int flags)
+wolfssl_sha256_init(void* context, unsigned int flags)
 {
   int ret = 0;
   SHA256_CONTEXT *hd = (SHA256_CONTEXT*)context;
   (void)flags;
 
-  ret = wc_InitSha256(&hd->wc_sha2);
+  ret = wc_InitSha256((wc_Sha256*)&hd->wc_sha2);
   if (ret != 0) {
     printf("Error libgcrypt (sha256_init): wc_InitSha256 failed\n");
     printf("Return: %d\n", ret);
@@ -836,14 +805,14 @@ wolfssl_sha224_final(void *context)
   byte temp_buffer[WC_SHA224_DIGEST_SIZE];
 
   if (hd->bctx.count > 0) {
-    ret = wc_Sha224Update(&hd->wc_sha2, hd->bctx.buf, hd->bctx.count);
+    ret = wc_Sha224Update((wc_Sha224*)&hd->wc_sha2, hd->bctx.buf, hd->bctx.count);
     if (ret != 0) {
       printf("Error libgcrypt (wolfssl_sha224_final): wc_Sha224Update failed\n");
       printf("Return: %d\n", ret);
     }
   }
 
-  ret = wc_Sha224Final(&hd->wc_sha2, temp_buffer);
+  ret = wc_Sha224Final((wc_Sha224*)&hd->wc_sha2, temp_buffer);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha224_final): wc_Sha224Final failed\n");
     printf("Return: %d\n", ret);
@@ -865,7 +834,7 @@ wolfssl_sha256_final(void *context)
 
   /* First update with any remaining bytes in the buffer */
   if (hd->bctx.count > 0) {
-    ret = wc_Sha256Update(&hd->wc_sha2, hd->bctx.buf, hd->bctx.count);
+    ret = wc_Sha256Update((wc_Sha256*)&hd->wc_sha2, hd->bctx.buf, hd->bctx.count);
     if (ret != 0) {
       printf("Error libgcrypt (sha256_final): wc_Sha256Update failed\n");
       printf("Return: %d\n", ret);
@@ -873,7 +842,7 @@ wolfssl_sha256_final(void *context)
   }
   /* Might need to use wc_Sha256GetHash instead of wc_Sha256Final */
   /* This is due to sha256_final does not necassarly mean the hash is ready */
-  ret = wc_Sha256Final(&hd->wc_sha2, temp_buffer);
+  ret = wc_Sha256Final((wc_Sha256*)&hd->wc_sha2, temp_buffer);
   if (ret != 0) {
     printf("Error libgcrypt (sha256_final): wc_Sha256Final failed\n");
     printf("Return: %d\n", ret);
@@ -1100,8 +1069,6 @@ const gcry_md_spec_t _gcry_digest_spec_sha224 =
     _gcry_wolfssl_sha224_hash_buffers,
     sizeof(SHA256_CONTEXT),
     run_selftests
-    //wolfssl_sha224_digest_alloc,
-    //wolfssl_sha224_digest_free,
   };
 
 const gcry_md_spec_t _gcry_digest_spec_sha256 =
@@ -1112,8 +1079,6 @@ const gcry_md_spec_t _gcry_digest_spec_sha256 =
     _gcry_wolfssl_sha256_hash_buffers,
     sizeof(SHA256_CONTEXT),
     run_selftests
-    //wolfssl_sha256_digest_alloc,
-    //wolfssl_sha256_digest_free,
   };
 #endif /* HAVE_WOLFSSL */
 

--- a/cipher/sha512.c
+++ b/cipher/sha512.c
@@ -176,6 +176,7 @@ typedef struct
 #endif
 } SHA512_CONTEXT;
 
+#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_NOSHA512_224) || defined(WOLFSSL_NOSHA512_256)
 static ATTR_ALIGNED_64 const u64 k[] =
   {
     U64_C(0x428a2f98d728ae22), U64_C(0x7137449123ef65cd),
@@ -219,7 +220,7 @@ static ATTR_ALIGNED_64 const u64 k[] =
     U64_C(0x4cc5d4becb3e42b6), U64_C(0x597f299cfc657e2a),
     U64_C(0x5fcb6fab3ad6faec), U64_C(0x6c44198c4a475817)
   };
-
+#endif
 
 /* AMD64 assembly implementations use SystemV ABI, ABI conversion and additional
  * stack to store XMM6-XMM15 needed on Win64. */
@@ -236,7 +237,7 @@ static ATTR_ALIGNED_64 const u64 k[] =
 # endif
 #endif
 
-
+#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_NOSHA512_224) || defined(WOLFSSL_NOSHA512_256)
 #ifdef USE_ARM64_SHA512
 unsigned int _gcry_sha512_transform_armv8_ce (u64 state[8],
                                               const unsigned char *data,
@@ -426,7 +427,6 @@ do_sha512_final_s390x (void *ctx, const unsigned char *data, size_t datalen,
 }
 #endif
 
-
 static void
 sha512_init_common (SHA512_CONTEXT *ctx, unsigned int flags)
 {
@@ -493,7 +493,7 @@ sha512_init_common (SHA512_CONTEXT *ctx, unsigned int flags)
   (void)features;
 }
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 static void
 sha512_init (void *context, unsigned int flags)
 {
@@ -529,8 +529,7 @@ sha384_init (void *context, unsigned int flags)
 
   sha512_init_common (ctx, flags);
 }
-
-
+#endif
 static void
 sha512_256_init (void *context, unsigned int flags)
 {
@@ -549,7 +548,6 @@ sha512_256_init (void *context, unsigned int flags)
   sha512_init_common (ctx, flags);
 }
 
-
 static void
 sha512_224_init (void *context, unsigned int flags)
 {
@@ -567,8 +565,6 @@ sha512_224_init (void *context, unsigned int flags)
 
   sha512_init_common (ctx, flags);
 }
-
-
 
 #ifndef USE_ARM_ASM
 
@@ -841,7 +837,6 @@ do_transform_generic (void *context, const unsigned char *data, size_t nblks)
 }
 #endif /*!USE_ARM_ASM*/
 
-
 /* The routine final terminates the computation and
  * returns the digest.
  * The handle is prepared for a new cycle, but adding bytes to the
@@ -936,7 +931,7 @@ sha512_read (void *context)
   return hd->bctx.buf;
 }
 
-
+#ifndef ENABLED_WOLFSSL_FIPS
 /* Shortcut functions which puts the hash value of the supplied buffer iov
  * into outbuf which must have a size of 64 bytes.  */
 static void
@@ -954,9 +949,9 @@ _gcry_sha512_hash_buffers (void *outbuf, size_t nbytes,
   sha512_final (&hd);
   memcpy (outbuf, hd.bctx.buf, 64);
 }
+#endif
 
-
-
+#ifndef ENABLED_WOLFSSL_FIPS
 /* Shortcut functions which puts the hash value of the supplied buffer iov
  * into outbuf which must have a size of 48 bytes.  */
 static void
@@ -974,7 +969,7 @@ _gcry_sha384_hash_buffers (void *outbuf, size_t nbytes,
   sha512_final (&hd);
   memcpy (outbuf, hd.bctx.buf, 48);
 }
-
+#endif
 
 
 /* Shortcut functions which puts the hash value of the supplied buffer iov
@@ -1014,7 +1009,7 @@ _gcry_sha512_224_hash_buffers (void *outbuf, size_t nbytes,
   sha512_final (&hd);
   memcpy (outbuf, hd.bctx.buf, 28);
 }
-
+#endif
 
 /* wolfCrypt port - Start */
 #if defined(HAVE_WOLFSSL)
@@ -1038,7 +1033,7 @@ wolfssl_sha384_transform_generic (void *ctx, const unsigned char *data, size_t n
   int ret = 0;
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)ctx;
 
-  ret = wc_Sha384Update(&hd->wc_sha512, data, 128 * nblks);
+  ret = wc_Sha384Update((wc_Sha384*)&hd->wc_sha512, data, 128 * nblks);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha384_transform_generic): wc_Sha384Update failed\n");
     printf("Return: %d\n", ret);
@@ -1053,7 +1048,7 @@ wolfssl_sha512_transform_generic (void *ctx, const unsigned char *data, size_t n
   int ret = 0;
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)ctx;
 
-  ret = wc_Sha512Update(&hd->wc_sha512, data, 128 * nblks);
+  ret = wc_Sha512Update((wc_Sha512*)&hd->wc_sha512, data, 128 * nblks);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_transform_generic): wc_Sha512Update failed\n");
     printf("Return: %d\n", ret);
@@ -1068,7 +1063,7 @@ wolfssl_sha512_224_transform_generic (void *ctx, const unsigned char *data, size
   int ret = 0;
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)ctx;
 
-  ret = wc_Sha512_224Update(&hd->wc_sha512, data, 128 * nblks);
+  ret = wc_Sha512_224Update((wc_Sha512_224*)&hd->wc_sha512, data, 128 * nblks);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_224_transform_generic): wc_Sha512_224Update failed\n");
     printf("Return: %d\n", ret);
@@ -1085,7 +1080,7 @@ wolfssl_sha512_256_transform_generic (void *ctx, const unsigned char *data, size
   int ret = 0;
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)ctx;
 
-  ret = wc_Sha512_256Update(&hd->wc_sha512, data, 128 * nblks);
+  ret = wc_Sha512_256Update((wc_Sha512_256*)&hd->wc_sha512, data, 128 * nblks);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_256_transform_generic): wc_Sha512_256Update failed\n");
     printf("Return: %d\n", ret);
@@ -1162,7 +1157,7 @@ wolfssl_sha384_init(void* context, unsigned int flags)
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)context;
   (void)flags;
 
-  ret = wc_InitSha384(&hd->wc_sha512);
+  ret = wc_InitSha384((wc_Sha384*)&hd->wc_sha512);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha384_init): wc_InitSha384 failed\n");
     printf("Return: %d\n", ret);
@@ -1178,7 +1173,7 @@ wolfssl_sha512_init(void* context, unsigned int flags)
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)context;
   (void)flags;
 
-  ret = wc_InitSha512(&hd->wc_sha512);
+  ret = wc_InitSha512((wc_Sha512*)&hd->wc_sha512);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_init): wc_InitSha512 failed\n");
     printf("Return: %d\n", ret);
@@ -1195,7 +1190,7 @@ wolfssl_sha512_224_init(void* context, unsigned int flags)
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)context;
   (void)flags;
 
-  ret = wc_InitSha512_224(&hd->wc_sha512);
+  ret = wc_InitSha512_224((wc_Sha512_224*)&hd->wc_sha512);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_224_init): wc_InitSha512_224 failed\n");
     printf("Return: %d\n", ret);
@@ -1213,7 +1208,7 @@ wolfssl_sha512_256_init(void* context, unsigned int flags)
   WOLF_SHA512_CONTEXT *hd = (WOLF_SHA512_CONTEXT*)context;
   (void)flags;
 
-  ret = wc_InitSha512_256(&hd->wc_sha512);
+  ret = wc_InitSha512_256((wc_Sha512_256*)&hd->wc_sha512);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_256_init): wc_InitSha512_256 failed\n");
     printf("Return: %d\n", ret);
@@ -1238,14 +1233,14 @@ wolfssl_sha384_final(void *context)
   byte temp_buffer[WC_SHA384_DIGEST_SIZE];
 
   if (hd->bctx.count > 0) {
-    ret = wc_Sha384Update(&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
+    ret = wc_Sha384Update((wc_Sha384*)&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
     if (ret != 0) {
       printf("Error libgcrypt (wolfssl_sha384_final): wc_Sha384Update failed\n");
       printf("Return: %d\n", ret);
     }
   }
 
-  ret = wc_Sha384Final(&hd->wc_sha512, temp_buffer);
+  ret = wc_Sha384Final((wc_Sha384*)&hd->wc_sha512, temp_buffer);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha384_final): wc_Sha384Final failed\n");
     printf("Return: %d\n", ret);
@@ -1264,14 +1259,14 @@ wolfssl_sha512_final(void *context)
   byte temp_buffer[WC_SHA512_DIGEST_SIZE];
 
   if (hd->bctx.count > 0) {
-    ret = wc_Sha512Update(&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
+    ret = wc_Sha512Update((wc_Sha512*)&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
     if (ret != 0) {
       printf("Error libgcrypt (wolfssl_sha512_final): wc_Sha512Update failed\n");
       printf("Return: %d\n", ret);
     }
   }
 
-  ret = wc_Sha512Final(&hd->wc_sha512, temp_buffer);
+  ret = wc_Sha512Final((wc_Sha512*)&hd->wc_sha512, temp_buffer);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_final): wc_Sha512Final failed\n");
     printf("Return: %d\n", ret);
@@ -1291,14 +1286,14 @@ wolfssl_sha512_224_final(void *context)
   byte temp_buffer[WC_SHA512_224_DIGEST_SIZE];
 
   if (hd->bctx.count > 0) {
-    ret = wc_Sha512_224Update(&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
+    ret = wc_Sha512_224Update((wc_Sha512_224*)&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
     if (ret != 0) {
       printf("Error libgcrypt (wolfssl_sha512_224_final): wc_Sha512_224Update failed\n");
       printf("Return: %d\n", ret);
     }
   }
 
-  ret = wc_Sha512_224Final(&hd->wc_sha512, temp_buffer);
+  ret = wc_Sha512_224Final((wc_Sha512_224*)&hd->wc_sha512, temp_buffer);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_224_final): wc_Sha512_224Final failed\n");
     printf("Return: %d\n", ret);
@@ -1319,14 +1314,14 @@ wolfssl_sha512_256_final(void *context)
   byte temp_buffer[WC_SHA512_256_DIGEST_SIZE];
 
   if (hd->bctx.count > 0) {
-    ret = wc_Sha512_256Update(&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
+    ret = wc_Sha512_256Update((wc_Sha512_256*)&hd->wc_sha512, hd->bctx.buf, hd->bctx.count);
     if (ret != 0) {
       printf("Error libgcrypt (wolfssl_sha512_256_final): wc_Sha512_256Update failed\n");
       printf("Return: %d\n", ret);
     }
   }
 
-  ret = wc_Sha512_256Final(&hd->wc_sha512, temp_buffer);
+  ret = wc_Sha512_256Final((wc_Sha512_256*)&hd->wc_sha512, temp_buffer);
   if (ret != 0) {
     printf("Error libgcrypt (wolfssl_sha512_256_final): wc_Sha512_256Final failed\n");
     printf("Return: %d\n", ret);
@@ -1765,7 +1760,7 @@ const gcry_md_spec_t _gcry_digest_spec_sha512_256 =
     GCRY_MD_SHA512_256, {0, 0}, /* Turn off FIPS mode for SHA512_256 */
     #endif
     "SHA512_256", sha512_256_asn, DIM (sha512_256_asn), oid_spec_sha512_256, 32,
-    #if defined(HAVE_WOLFSSL) && !defined(WOLFSSL_NO_SHAKE256)
+    #if defined(HAVE_WOLFSSL) && !defined(WOLFSSL_NOSHA512_256)
     wolfssl_sha512_256_init, _gcry_md_block_write, wolfssl_sha512_256_final, wolfssl_sha512_read, NULL,
     _gcry_wolfssl_sha512_256_hash_buffers,
     #else

--- a/random/random-csprng.c
+++ b/random/random-csprng.c
@@ -211,10 +211,14 @@ static struct
 
 
 /* ---  Prototypes  --- */
+#ifndef HAVE_WOLFSSL
 static void read_pool (byte *buffer, size_t length, int level );
+#endif
 static void add_randomness (const void *buffer, size_t length,
                             enum random_origins origin);
+#ifndef HAVE_WOLFSSL
 static void random_poll (void);
+#endif
 static void do_fast_random_poll (void);
 static int (*getfnc_gather_random (void))(void (*)(const void*, size_t,
                                                    enum random_origins),
@@ -222,9 +226,10 @@ static int (*getfnc_gather_random (void))(void (*)(const void*, size_t,
 static void (*getfnc_fast_random_poll (void))(void (*)(const void*, size_t,
                                                        enum random_origins),
                                               enum random_origins);
+#ifndef HAVE_WOLFSSL
 static void read_random_source (enum random_origins origin,
                                 size_t length, int level);
-
+#endif
 
 
 /* ---  Functions  --- */
@@ -766,7 +771,7 @@ lock_seed_file (int fd, const char *fname, int for_write)
   return 0;
 }
 
-
+#ifndef HAVE_WOLFSSL
 /* Read in a seed from the random_seed file and return true if this
    was successful.
 
@@ -886,7 +891,7 @@ read_seed_file (void)
   allow_seed_file_update = 1;
   return 1;
 }
-
+#endif
 
 void
 _gcry_rngcsprng_update_seed_file (void)
@@ -966,7 +971,7 @@ _gcry_rngcsprng_update_seed_file (void)
   unlock_pool ();
 }
 
-
+#ifndef HAVE_WOLFSSL
 /* Read random out of the pool.  This function is the core of the
    public random functions.  Note that Level GCRY_WEAK_RANDOM is not
    anymore handled special and in fact is an alias in the API for
@@ -1113,7 +1118,7 @@ read_pool (byte *buffer, size_t length, int level)
       goto retry;
     }
 }
-
+#endif
 
 
 /* Add LENGTH bytes of randomness from buffer to the pool.  ORIGIN is
@@ -1155,14 +1160,14 @@ add_randomness (const void *buffer, size_t length, enum random_origins origin)
 }
 
 
-
+#ifndef HAVE_WOLFSSL
 static void
 random_poll (void)
 {
   rndstats.slowpolls++;
   read_random_source (RANDOM_ORIGIN_SLOWPOLL, POOLSIZE/5, GCRY_STRONG_RANDOM);
 }
-
+#endif
 
 /* Runtime determination of the slow entropy gathering module.  */
 static int (*
@@ -1331,8 +1336,7 @@ _gcry_rngcsprng_fast_poll (void)
   unlock_pool ();
 }
 
-
-
+#ifndef HAVE_WOLFSSL
 static void
 read_random_source (enum random_origins origin, size_t length, int level)
 {
@@ -1342,3 +1346,4 @@ read_random_source (enum random_origins origin, size_t length, int level)
   if (slow_gather_fnc (add_randomness, origin, length, level) < 0)
     log_fatal ("No way to gather entropy for the RNG\n");
 }
+#endif

--- a/random/random-system.c
+++ b/random/random-system.c
@@ -106,7 +106,7 @@ unlock_rng (void)
                gpg_strerror (rc));
 }
 
-
+#ifndef HAVE_WOLFSSL
 /* Helper variables for read_cb().
 
    The _gcry_rnd*_gather_random interface does not allow to provide a
@@ -117,8 +117,9 @@ unlock_rng (void)
 static unsigned char *read_cb_buffer;   /* The buffer.  */
 static size_t         read_cb_size;     /* Size of the buffer.  */
 static size_t         read_cb_len;      /* Used length.  */
+#endif
 
-
+#ifndef HAVE_WOLFSSL
 /* Callback for _gcry_rnd*_gather_random.  */
 static void
 read_cb (const void *buffer, size_t length, enum random_origins origin)
@@ -137,6 +138,7 @@ read_cb (const void *buffer, size_t length, enum random_origins origin)
       read_cb_buffer[read_cb_len++] = *p++;
     }
 }
+#endif
 
 
 /* Fill BUFFER with LENGTH bytes of random at quality LEVEL.  The

--- a/random/random.c
+++ b/random/random.c
@@ -68,8 +68,9 @@ static struct
 
 /* This is the lock we use to protect the buffer used by the nonce
    generation.  */
+#ifndef HAVE_WOLFSSL
 GPGRT_LOCK_DEFINE (nonce_buffer_lock);
-
+#endif
 
 
 /* ---  Functions  --- */

--- a/src/fips.c
+++ b/src/fips.c
@@ -368,12 +368,12 @@ _gcry_fips_indicator_cipher (va_list arg_ptr)
 #if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
         case GCRY_CIPHER_MODE_CFB:
 #else
-        #warning "FIPS version of wolfcrypt does not support CFB"
+        #pragma message "FIPS version of wolfcrypt does not support CFB"
 #endif
 #if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
         case GCRY_CIPHER_MODE_CFB8:
 #else
-        #warning "FIPS version of wolfcrypt does not support CFB8"
+        #pragma message "FIPS version of wolfcrypt does not support CFB8"
 #endif
         case GCRY_CIPHER_MODE_OFB:
         case GCRY_CIPHER_MODE_CTR:
@@ -382,12 +382,12 @@ _gcry_fips_indicator_cipher (va_list arg_ptr)
 #if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_XTS)
         case GCRY_CIPHER_MODE_XTS:
 #else
-        #warning "FIPS version of wolfcrypt does not support XTS"
+        #pragma message "FIPS version of wolfcrypt does not support XTS"
 #endif
 #if !defined(HAVE_WOLFSSL) || !defined(ENABLED_WOLFSSL_FIPS)
         case GCRY_CIPHER_MODE_AESWRAP:
 #else
-        #warning "FIPS version of wolfcrypt does not support AESWRAP"
+        #pragma message "FIPS version of wolfcrypt does not support AESWRAP"
 #endif
           return GPG_ERR_NO_ERROR;
         default:

--- a/src/fips.c
+++ b/src/fips.c
@@ -365,29 +365,25 @@ _gcry_fips_indicator_cipher (va_list arg_ptr)
         {
         case GCRY_CIPHER_MODE_ECB:
         case GCRY_CIPHER_MODE_CBC:
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
+        /* FIPS version of wolfcrypt does not support CFB */
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_CFB)
         case GCRY_CIPHER_MODE_CFB:
-#else
-        #pragma message "FIPS version of wolfcrypt does not support CFB"
 #endif
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
+        /* FIPS version of wolfcrypt does not support CFB8 */
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_CFB)
         case GCRY_CIPHER_MODE_CFB8:
-#else
-        #pragma message "FIPS version of wolfcrypt does not support CFB8"
 #endif
         case GCRY_CIPHER_MODE_OFB:
         case GCRY_CIPHER_MODE_CTR:
         case GCRY_CIPHER_MODE_CCM:
         case GCRY_CIPHER_MODE_GCM:
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_XTS)
+        /* FIPS version of wolfcrypt does not support XTS */
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_XTS)
         case GCRY_CIPHER_MODE_XTS:
-#else
-        #pragma message "FIPS version of wolfcrypt does not support XTS"
 #endif
-#if !defined(HAVE_WOLFSSL) || !defined(ENABLED_WOLFSSL_FIPS)
+        /* FIPS version of wolfcrypt does not support AESWRAP */
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(ENABLED_WOLFSSL_FIPS)
         case GCRY_CIPHER_MODE_AESWRAP:
-#else
-        #pragma message "FIPS version of wolfcrypt does not support AESWRAP"
 #endif
           return GPG_ERR_NO_ERROR;
         default:

--- a/src/global.c
+++ b/src/global.c
@@ -95,10 +95,10 @@ static void
 global_init (void)
 {
   gcry_error_t err = 0;
+#if defined (HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
   static int is_wolfssl_on = 0;
 
 /* add wolfSSL initialization here */
-#if defined (HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
   if (is_wolfssl_on == 0) {
     is_wolfssl_on = 1;
     if (wc_SetSeed_Cb(wc_GenerateSeed) != 0) {

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -41,7 +41,7 @@
 #define PGM "basic"
 #include "t-common.h"
 
-#if defined(HAVE_WOLFSSL) && defined(ENABLED_WOLFSSL_FIPS)
+#if defined(HAVE_WOLFSSL)
 #include "wolfssl/options.h"
 #include "wolfssl/wolfcrypt/settings.h"
 #endif
@@ -100,6 +100,7 @@ mismatch (const void *expected, size_t expectedlen,
    representation and return it as an allocated buffer. The valid
    length of the buffer is returned at R_LENGTH.  The string is
    delimited by end of string.  The function terminates on error.  */
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void *
 hex2buffer (const char *string, size_t *r_length)
 {
@@ -118,7 +119,7 @@ hex2buffer (const char *string, size_t *r_length)
   *r_length = length;
   return buffer;
 }
-
+#endif
 
 static void
 show_sexp (const char *prefix, gcry_sexp_t a)
@@ -2745,6 +2746,7 @@ check_ctr_cipher (void)
     fprintf (stderr, "  Completed CTR cipher checks.\n");
 }
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_cfb_cipher (void)
 {
@@ -3269,6 +3271,7 @@ check_cfb_cipher (void)
   if (verbose)
     fprintf (stderr, "  Completed CFB checks.\n");
 }
+#endif
 
 static void
 check_ofb_cipher (void)
@@ -4790,6 +4793,7 @@ check_gcm_cipher (void)
 }
 
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 _check_eax_cipher (unsigned int step)
 {
@@ -5306,8 +5310,9 @@ _check_eax_cipher (unsigned int step)
   if (verbose)
     fprintf (stderr, "  Completed EAX checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_eax_cipher (void)
 {
@@ -5320,8 +5325,10 @@ check_eax_cipher (void)
   /* Split input to 16 byte buffers. */
   _check_eax_cipher(16);
 }
+#endif
 
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_siv_cipher (void)
 {
@@ -5739,8 +5746,9 @@ check_siv_cipher (void)
   if (verbose)
     fprintf (stderr, "  Completed SIV checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_gcm_siv_cipher (void)
 {
@@ -7215,8 +7223,9 @@ check_gcm_siv_cipher (void)
   if (verbose)
     fprintf (stderr, "  Completed GCM-SIV checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 _check_poly1305_cipher (unsigned int step)
 {
@@ -7718,8 +7727,9 @@ _check_poly1305_cipher (unsigned int step)
   if (verbose)
     fprintf (stderr, "  Completed POLY1305 checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_poly1305_cipher (void)
 {
@@ -7732,7 +7742,7 @@ check_poly1305_cipher (void)
   /* Split input to 16 byte buffers. */
   _check_poly1305_cipher(16);
 }
-
+#endif
 
 static void
 check_ccm_cipher (void)
@@ -8555,6 +8565,7 @@ check_ccm_cipher (void)
 }
 
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 do_check_ocb_cipher (int inplace)
 {
@@ -9058,8 +9069,9 @@ do_check_ocb_cipher (int inplace)
   if (verbose)
     fprintf (stderr, "  Completed OCB checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_ocb_cipher_largebuf_split (int algo, int keylen, const char *tagexpect,
 				 unsigned int splitpos)
@@ -9282,8 +9294,9 @@ out_free:
   xfree(outbuf);
   xfree(inbuf);
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_ocb_cipher_checksum (int algo, int keylen)
 {
@@ -9463,8 +9476,9 @@ out_free:
   xfree(inbuf);
   xfree(outbuf);
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_ocb_cipher_largebuf (int algo, int keylen, const char *tagexpect)
 {
@@ -9477,8 +9491,9 @@ check_ocb_cipher_largebuf (int algo, int keylen, const char *tagexpect)
 
   check_ocb_cipher_checksum(algo, keylen);
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_ocb_cipher_splitaad (void)
 {
@@ -9717,8 +9732,9 @@ check_ocb_cipher_splitaad (void)
   xfree (plain);
   xfree (key);
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_ocb_cipher (void)
 {
@@ -9772,9 +9788,10 @@ check_ocb_cipher (void)
   /* Check that the AAD data is correctly buffered.  */
   check_ocb_cipher_splitaad ();
 }
+#endif
 
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 do_check_xts_cipher (int inplace)
 {
@@ -10097,8 +10114,9 @@ next_tv:
   if (verbose)
     fprintf (stderr, "  Completed XTS checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_xts_cipher (void)
 {
@@ -10109,8 +10127,9 @@ check_xts_cipher (void)
   /* Check XTS cipher with inplace encrypt/decrypt. */
   do_check_xts_cipher(1);
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_gost28147_cipher_basic (enum gcry_cipher_algos algo)
 {
@@ -10300,14 +10319,18 @@ check_gost28147_cipher_basic (enum gcry_cipher_algos algo)
   (void) algo;
 #endif
 }
+#endif
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_gost28147_cipher (void)
 {
 	check_gost28147_cipher_basic (GCRY_CIPHER_GOST28147);
 	check_gost28147_cipher_basic (GCRY_CIPHER_GOST28147_MESH);
 }
+#endif
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_stream_cipher (void)
 {
@@ -10988,8 +11011,9 @@ check_stream_cipher (void)
   if (verbose)
     fprintf (stderr, "  Completed stream cipher checks.\n");
 }
+#endif
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_stream_cipher_large_block (void)
 {
@@ -11442,7 +11466,7 @@ check_stream_cipher_large_block (void)
   if (verbose)
     fprintf (stderr, "  Completed large block stream cipher checks.\n");
 }
-
+#endif
 
 
 /* Check that our bulk encryption functions work properly.  */
@@ -11459,7 +11483,7 @@ check_bulk_cipher_modes (void)
     int ivlen;
     char t1_hash[20];
   } tv[] = {
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_CFB)
     { GCRY_CIPHER_AES, GCRY_CIPHER_MODE_CFB,
       "abcdefghijklmnop", 16,
       "1234567890123456", 16,
@@ -11566,7 +11590,7 @@ check_bulk_cipher_modes (void)
       { 0x2d, 0x71, 0x54, 0xb9, 0xc5, 0x28, 0x76, 0xff, 0x76, 0xb5,
         0x99, 0x37, 0x99, 0x9d, 0xf7, 0x10, 0x6d, 0x86, 0x4f, 0x3f }
     },
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_XTS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_XTS)
     { GCRY_CIPHER_AES128, GCRY_CIPHER_MODE_XTS,
       "abcdefghijklmnopABCDEFGHIJKLMNOP", 32,
       "1234567890123456", 16,
@@ -12806,7 +12830,7 @@ cipher_cbc_bulk_test (int cipher_algo)
   return -1;
 }
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 buf_xor_2dst(void *vdst1, void *vdst2, const void *vsrc, size_t len)
 {
@@ -12817,7 +12841,9 @@ buf_xor_2dst(void *vdst1, void *vdst2, const void *vsrc, size_t len)
   for (; len; len--)
     *dst1++ = (*dst2++ ^= *src++);
 }
+#endif
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 /* Run the tests for <block cipher>-CFB-<block size>, tests bulk CFB
    decryption.  Returns NULL on success. */
 static int
@@ -13044,7 +13070,7 @@ cipher_cfb_bulk_test (int cipher_algo)
   xfree(mem);
   return -1;
 }
-
+#endif
 
 /* Run the tests for <block cipher>-CTR-<block size>, tests IV increment
    of bulk CTR encryption.  Returns NULL on success. */
@@ -13492,7 +13518,7 @@ check_ciphers (void)
 		 gcry_cipher_map_name (gcry_cipher_algo_name (algos[i])));
 
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_ECB, 0);
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_CFB)
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_CFB, 0);
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_CFB8, 0);
 #endif
@@ -13500,18 +13526,18 @@ check_ciphers (void)
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_CBC, 0);
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_CBC, GCRY_CIPHER_CBC_CTS);
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_CTR, 0);
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_EAX)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_EAX)
       check_one_cipher (algos[i], GCRY_CIPHER_MODE_EAX, 0);
 #endif
       if (gcry_cipher_get_algo_blklen (algos[i]) == GCRY_CCM_BLOCK_LEN)
         check_one_cipher (algos[i], GCRY_CIPHER_MODE_CCM, 0);
       if (gcry_cipher_get_algo_blklen (algos[i]) == GCRY_GCM_BLOCK_LEN)
         check_one_cipher (algos[i], GCRY_CIPHER_MODE_GCM, 0);
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_OCB)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_OCB)
       if (gcry_cipher_get_algo_blklen (algos[i]) == GCRY_OCB_BLOCK_LEN)
         check_one_cipher (algos[i], GCRY_CIPHER_MODE_OCB, 0);
 #endif
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_XTS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_XTS)
       if (gcry_cipher_get_algo_blklen (algos[i]) == GCRY_XTS_BLOCK_LEN)
         check_one_cipher (algos[i], GCRY_CIPHER_MODE_XTS, 0);
 #endif
@@ -13519,7 +13545,7 @@ check_ciphers (void)
       if (gcry_cipher_get_algo_blklen (algos[i]) >= 8)
         {
           cipher_cbc_bulk_test (algos[i]);
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_CFB)
           cipher_cfb_bulk_test (algos[i]);
 #endif
           cipher_ctr_bulk_test (algos[i]);
@@ -13572,7 +13598,7 @@ check_cipher_modes(void)
   check_aes128_cbc_cts_cipher ();
   check_cbc_mac_cipher ();
   check_ctr_cipher ();
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_CFB)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_CFB)
   check_cfb_cipher ();
 #endif
   check_ofb_cipher ();
@@ -13583,29 +13609,29 @@ check_cipher_modes(void)
        * as late as in gcry_cipher_gettag, but we want to allow it in the end */
       check_gcm_cipher ();
     }
-#if !defined(HAVE_WOLFSSL) || defined(HAVE_POLY1305)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(HAVE_POLY1305)
   check_poly1305_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || !defined(ENABLED_WOLFSSL_FIPS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(ENABLED_WOLFSSL_FIPS)
   check_ocb_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_XTS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_XTS)
   check_xts_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_EAX)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_EAX)
   check_eax_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_AES_SIV)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_AES_SIV)
   check_siv_cipher ();
   check_gcm_siv_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || !defined(ENABLED_WOLFSSL_FIPS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(ENABLED_WOLFSSL_FIPS)
   check_gost28147_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || !defined(ENABLED_WOLFSSL_FIPS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(ENABLED_WOLFSSL_FIPS)
   check_stream_cipher ();
 #endif
-#if !defined(HAVE_WOLFSSL) || !defined(ENABLED_WOLFSSL_FIPS)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(ENABLED_WOLFSSL_FIPS)
   check_stream_cipher_large_block ();
 #endif
   if (verbose)
@@ -13696,6 +13722,7 @@ alex_hkdf()
     if (memcmp(output, expected_key, 16) != 0){
         printf("ALEX: Keys do not equal\n");
     }
+  (void)gcry;
 }
 
 static void
@@ -14408,7 +14435,7 @@ check_digests (void)
         "\x74\xee\x78\xeb\x79\x1f\x94\x38\x5b\x73\xef\xf8\xfd\x5d\x74\xd8"
         "\x51\x36\xfe\x63\x52\xde\x07\x70\x95\xd6\x78\x2b\x7b\x46\x8a\x2c"
         "\x30\x0f\x48\x0c\x74\x43\x06\xdb\xa3\x8d\x64\x3d\xe9\xa1\xa7\x72" },
-#if !defined(HAVE_WOLFSSL) || !defined(WOLFSSL_NOSHA512_256)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(WOLFSSL_NOSHA512_256)
       { GCRY_MD_SHA512_256, "abc",
 	"\x53\x04\x8E\x26\x81\x94\x1E\xF9\x9B\x2E\x29\xB7\x6B\x4C\x7D\xAB"
 	"\xE4\xC2\xD0\xC6\x34\xFC\x6D\x46\xE0\xE2\xF1\x31\x07\xE7\xAF\x23" },
@@ -14416,7 +14443,7 @@ check_digests (void)
 	"\x9a\x59\xa0\x52\x93\x01\x87\xa9\x70\x38\xca\xe6\x92\xf3\x07\x08"
 	"\xaa\x64\x91\x92\x3e\xf5\x19\x43\x94\xdc\x68\xd5\x6c\x74\xfb\x21" },
 #endif
-#if !defined(HAVE_WOLFSSL) || !defined(WOLFSSL_NOSHA512_224)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(WOLFSSL_NOSHA512_224)
       { GCRY_MD_SHA512_224, "abc",
 	"\x46\x34\x27\x0F\x70\x7B\x6A\x54\xDA\xAE\x75\x30\x46\x08\x42\xE2"
 	"\x0E\x37\xED\x26\x5C\xEE\xE9\xA4\x3E\x89\x24\xAA" },
@@ -15781,7 +15808,7 @@ check_hmac (void)
     const char *expect;
   } algos[] =
     {
-#if !defined(HAVE_WOLFSSL) || !defined(NO_MD5)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(NO_MD5)
       { GCRY_MD_MD5, "what do ya want for nothing?", "Jefe",
 	"\x75\x0c\x78\x3e\x6a\xb0\xb5\x03\xea\xa8\x6e\x31\x0a\x5d\xb7\x38" },
       { GCRY_MD_MD5,
@@ -16292,7 +16319,7 @@ check_mac (void)
     unsigned int klen;
   } algos[] =
     {
-#if !defined(HAVE_WOLFSSL) || !defined(NO_MD5)
+#if !defined(ENABLED_WOLFSSL_FIPS) || !defined(NO_MD5)
       { GCRY_MAC_HMAC_MD5, "what do ya want for nothing?", "Jefe",
         "\x75\x0c\x78\x3e\x6a\xb0\xb5\x03\xea\xa8\x6e\x31\x0a\x5d\xb7\x38" },
       { GCRY_MAC_HMAC_MD5,
@@ -17451,7 +17478,7 @@ check_pubkey_sign_ecdsa (int n, gcry_sexp_t skey, gcry_sexp_t pkey,
         /* */          "000102030405060708090A0B0C0D0E0F#))",
         0
       },
-#if defined(HAVE_WOLFSSL) && !defined(ENABLED_WOLFSSL_FIPS)
+#if !defined(ENABLED_WOLFSSL_FIPS)
       { 256,
         "(data (flags gost)\n"
         " (value #00112233445566778899AABBCCDDEEFF"
@@ -17477,7 +17504,7 @@ check_pubkey_sign_ecdsa (int n, gcry_sexp_t skey, gcry_sexp_t pkey,
         0
       },
 #endif
-#if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_SM2)
+#if !defined(ENABLED_WOLFSSL_FIPS) || defined(WOLFSSL_SM2)
       { 256,
         "(data (flags sm2)\n"
         " (hash sm3 #112233445566778899AABBCCDDEEFF00"

--- a/tests/bench-slope.c
+++ b/tests/bench-slope.c
@@ -1037,7 +1037,7 @@ bench_encrypt_init (struct bench_obj *obj)
   obj->num_measure_repetitions = num_measurement_repetitions;
 
   err = gcry_cipher_open (&hd, mode->algo, mode->mode, 0);
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
             #if !defined(WOLFSSL_AES_CFB)
             mode->mode == GCRY_CIPHER_MODE_CFB ||
@@ -1051,12 +1051,8 @@ bench_encrypt_init (struct bench_obj *obj)
             #if !defined(HAVE_POLY1305)
             mode->mode == GCRY_CIPHER_MODE_POLY1305 ||
             #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_STREAM ||
-            #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_OCB ||
-            #endif
             #if !defined(WOLFSSL_AES_SIV)
             mode->mode == GCRY_CIPHER_MODE_SIV ||
             mode->mode == GCRY_CIPHER_MODE_GCM_SIV ||
@@ -1105,7 +1101,7 @@ static void
 bench_encrypt_free (struct bench_obj *obj)
 {
   gcry_cipher_hd_t hd = obj->hd;
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   struct bench_cipher_mode *mode = obj->priv;
   if (
             #if !defined(WOLFSSL_AES_CFB)
@@ -1120,12 +1116,8 @@ bench_encrypt_free (struct bench_obj *obj)
             #if !defined(HAVE_POLY1305)
             mode->mode == GCRY_CIPHER_MODE_POLY1305 ||
             #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_STREAM ||
-            #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_OCB ||
-            #endif
             #if !defined(WOLFSSL_AES_SIV)
             mode->mode == GCRY_CIPHER_MODE_SIV ||
             mode->mode == GCRY_CIPHER_MODE_GCM_SIV ||
@@ -1144,7 +1136,7 @@ bench_encrypt_do_bench (struct bench_obj *obj, void *buf, size_t buflen)
 {
   gcry_cipher_hd_t hd = obj->hd;
   int err;
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   struct bench_cipher_mode *mode = obj->priv;
   if (
             #if !defined(WOLFSSL_AES_CFB)
@@ -1159,12 +1151,8 @@ bench_encrypt_do_bench (struct bench_obj *obj, void *buf, size_t buflen)
             #if !defined(HAVE_POLY1305)
             mode->mode == GCRY_CIPHER_MODE_POLY1305 ||
             #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_STREAM ||
-            #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_OCB ||
-            #endif
             #if !defined(WOLFSSL_AES_SIV)
             mode->mode == GCRY_CIPHER_MODE_SIV ||
             mode->mode == GCRY_CIPHER_MODE_GCM_SIV ||
@@ -1191,7 +1179,7 @@ bench_decrypt_do_bench (struct bench_obj *obj, void *buf, size_t buflen)
 {
   gcry_cipher_hd_t hd = obj->hd;
   int err;
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   struct bench_cipher_mode *mode = obj->priv;
   if (
             #if !defined(WOLFSSL_AES_CFB)
@@ -1206,12 +1194,8 @@ bench_decrypt_do_bench (struct bench_obj *obj, void *buf, size_t buflen)
             #if !defined(HAVE_POLY1305)
             mode->mode == GCRY_CIPHER_MODE_POLY1305 ||
             #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_STREAM ||
-            #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_OCB ||
-            #endif
             #if !defined(WOLFSSL_AES_SIV)
             mode->mode == GCRY_CIPHER_MODE_SIV ||
             mode->mode == GCRY_CIPHER_MODE_GCM_SIV ||
@@ -1259,7 +1243,7 @@ bench_xts_encrypt_init (struct bench_obj *obj)
   obj->num_measure_repetitions = num_measurement_repetitions;
 
   err = gcry_cipher_open (&hd, mode->algo, mode->mode, 0);
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
             #if !defined(WOLFSSL_AES_CFB)
             mode->mode == GCRY_CIPHER_MODE_CFB ||
@@ -1273,12 +1257,8 @@ bench_xts_encrypt_init (struct bench_obj *obj)
             #if !defined(HAVE_POLY1305)
             mode->mode == GCRY_CIPHER_MODE_POLY1305 ||
             #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_STREAM ||
-            #endif
-            #if defined(ENABLED_WOLFSSL_FIPS)
             mode->mode == GCRY_CIPHER_MODE_OCB ||
-            #endif
             #if !defined(WOLFSSL_AES_SIV)
             mode->mode == GCRY_CIPHER_MODE_SIV ||
             mode->mode == GCRY_CIPHER_MODE_GCM_SIV ||
@@ -2233,7 +2213,7 @@ hash_bench (char **argv, int argc)
   else
     {
       for (i = 1; i < 400; i++)
-        #if defined(HAVE_WOLFSSL)
+        #if defined(ENABLED_WOLFSSL_FIPS)
           if (
               #if defined(WOLFSSL_NOSHA512_224)
               i == GCRY_MD_SHA512_224 ||
@@ -2294,7 +2274,7 @@ bench_mac_init (struct bench_obj *obj)
   memset(key, 42, keylen);
 
   err = gcry_mac_open (&hd, mode->algo, 0, NULL);
-  #if defined(HAVE_WOLFSSL)
+  #if defined(ENABLED_WOLFSSL_FIPS)
   if (
         #if defined(WOLFSSL_NOSHA512_224)
         mode->algo == GCRY_MD_SHA512_224 ||
@@ -2356,7 +2336,7 @@ bench_mac_init (struct bench_obj *obj)
 static void
 bench_mac_free (struct bench_obj *obj)
 {
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   struct bench_mac_mode *mode = obj->priv;
   if (
         #if defined(WOLFSSL_NOSHA512_224)
@@ -2382,7 +2362,7 @@ bench_mac_do_bench (struct bench_obj *obj, void *buf, size_t buflen)
   gcry_mac_hd_t hd = obj->hd;
   size_t bs;
   char b;
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   struct bench_mac_mode *mode = obj->priv;
   if (
         #if defined(WOLFSSL_NOSHA512_224)
@@ -2435,7 +2415,7 @@ mac_bench_one (int algo, struct bench_mac_mode *pmode)
 
   result = do_slope_benchmark (&obj);
   bench_print_result (result);
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
         #if defined(WOLFSSL_NOSHA512_224)
         mode.algo == GCRY_MD_SHA512_224 ||
@@ -2905,7 +2885,7 @@ bench_ecc_mult_do_bench (struct bench_obj *obj, void *buf, size_t num_iter)
 
   (void)buf;
 
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
       #if !defined(HAVE_ED25519)
       on_ecc_algo == ECC_ALGO_ED25519 ||
@@ -3061,7 +3041,7 @@ bench_ecc_keygen (struct bench_ecc_hd *hd)
   gpg_error_t err;
 
   err = gcry_pk_genkey (&key_pair, hd->key_spec);
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
       #if !defined(HAVE_ED25519)
       on_ecc_algo == ECC_ALGO_ED25519 ||
@@ -3071,7 +3051,7 @@ bench_ecc_keygen (struct bench_ecc_hd *hd)
       #endif
       0) {
     if (strncmp(gpg_strerror(err), "Not supported", 13) != 0) {
-      fprintf (stderr, PGM ": Not expected error for `%s'\n");
+      fprintf (stderr, PGM ": Not expected error\n");
       exit (1);
     }
       return;
@@ -3129,7 +3109,7 @@ bench_ecc_sign_do_bench (struct bench_obj *obj, void *buf, size_t num_iter)
   (void)buf;
 
   bench_ecc_keygen (hd);
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
       #if !defined(HAVE_ED25519)
       on_ecc_algo == ECC_ALGO_ED25519 ||
@@ -3174,7 +3154,7 @@ bench_ecc_verify_do_bench (struct bench_obj *obj, void *buf, size_t num_iter)
   (void)buf;
 
   bench_ecc_keygen (hd);
-#if defined(HAVE_WOLFSSL)
+#if defined(ENABLED_WOLFSSL_FIPS)
   if (
       #if !defined(HAVE_ED25519)
       on_ecc_algo == ECC_ALGO_ED25519 ||

--- a/tests/pubkey.c
+++ b/tests/pubkey.c
@@ -206,6 +206,7 @@ _gcry_pk_util_get_nbits (gcry_sexp_t list, unsigned int *r_nbits)
    length of the buffer is returned at R_LENGTH.  The string is
    delimited by end of string.  The function returns NULL on
    error.  */
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void *
 data_from_hex (const char *string, size_t *r_length)
 {
@@ -224,7 +225,6 @@ data_from_hex (const char *string, size_t *r_length)
   *r_length = length;
   return buffer;
 }
-
 
 static void
 extract_cmp_data (gcry_sexp_t sexp, const char *name, const char *expected)
@@ -252,7 +252,7 @@ extract_cmp_data (gcry_sexp_t sexp, const char *name, const char *expected)
   gcry_free (b);
   gcry_sexp_release (l1);
 }
-
+#endif
 
 #if USE_RSA || USE_ELGAMAL
 static void

--- a/tests/t-ed25519.c
+++ b/tests/t-ed25519.c
@@ -60,7 +60,7 @@ show_note (const char *format, ...)
   va_end (arg_ptr);
 }
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 show_sexp (const char *prefix, gcry_sexp_t a)
 {
@@ -77,7 +77,7 @@ show_sexp (const char *prefix, gcry_sexp_t a)
   fprintf (stderr, "%.*s", (int)size, buf);
   gcry_free (buf);
 }
-
+#endif
 
 /* Prepend FNAME with the srcdir environment variable's value and
  * return an allocated filename.  */
@@ -207,6 +207,15 @@ one_test (int testno, const char *sk, const char *pk,
   unsigned char *sig_s = NULL;
   char *sig_rs_string = NULL;
   size_t sig_r_len, sig_s_len;
+
+  #if defined(ENABLED_WOLFSSL_FIPS) && !defined(HAVE_ED25519)
+  (void)sig_r_len;
+  (void)sig_s_len;
+  (void)s_tmp;
+  (void)s_tmp2;
+  (void)i;
+  (void)p;
+  #endif
 
   if (verbose > 1)
     info ("Running test %d\n", testno);
@@ -339,7 +348,7 @@ one_test (int testno, const char *sk, const char *pk,
     }
 #endif
 
-  if (!no_verify)
+  if (!no_verify) {
     if ((err = gcry_pk_hash_verify (s_sig, data_tmpl, s_pk, NULL, ctx))) {
         #if defined(ENABLED_WOLFSSL_FIPS) && !defined(HAVE_ED25519)
         if (strncmp(gpg_strerror(err), "Invalid object", 15) != 0) {
@@ -350,6 +359,7 @@ one_test (int testno, const char *sk, const char *pk,
               testno, gpg_strerror (err));
         #endif
       }
+  }
 
  leave:
   gcry_ctx_release (ctx);

--- a/tests/t-ed25519.c
+++ b/tests/t-ed25519.c
@@ -277,7 +277,7 @@ one_test (int testno, const char *sk, const char *pk,
 
   data_tmpl = "(data(value %b))";
   err = gcry_pk_hash_sign (&s_sig, data_tmpl, s_sk, NULL, ctx);
-#if !defined(HAVE_ED25519)
+#if defined(ENABLED_WOLFSSL_FIPS) && !defined(HAVE_ED25519)
   if (strncmp(gpg_strerror(err), "Not supported", 14) != 0) {
     fail("Should fail for ed25519");
   }
@@ -341,7 +341,7 @@ one_test (int testno, const char *sk, const char *pk,
 
   if (!no_verify)
     if ((err = gcry_pk_hash_verify (s_sig, data_tmpl, s_pk, NULL, ctx))) {
-        #if !defined(HAVE_ED25519)
+        #if defined(ENABLED_WOLFSSL_FIPS) && !defined(HAVE_ED25519)
         if (strncmp(gpg_strerror(err), "Invalid object", 15) != 0) {
             fail("Should fail for ed25519: %s", gpg_strerror(err));
         }

--- a/tests/t-ed448.c
+++ b/tests/t-ed448.c
@@ -54,7 +54,7 @@ show_note (const char *format, ...)
   va_end (arg_ptr);
 }
 
-
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 show_sexp (const char *prefix, gcry_sexp_t a)
 {
@@ -71,7 +71,7 @@ show_sexp (const char *prefix, gcry_sexp_t a)
   fprintf (stderr, "%.*s", (int)size, buf);
   gcry_free (buf);
 }
-
+#endif
 
 /* Prepend FNAME with the srcdir environment variable's value and
  * return an allocated filename.  */
@@ -298,7 +298,7 @@ one_test (int testno, int ph, const char *sk, const char *pk,
     }
 
   err = gcry_pk_hash_sign (&s_sig, data_tmpl, s_sk, NULL, ctx);
-  #if !defined(HAVE_ED448)
+  #if defined(ENABLED_WOLFSSL_FIPS) && !defined(HAVE_ED448)
   if (strncmp(gpg_strerror(err), "Not supported", 14) != 0) {
     fail("Should fail for ed448: %s", gpg_strerror(err));
   }
@@ -355,9 +355,18 @@ one_test (int testno, int ph, const char *sk, const char *pk,
     }
 #endif
 
-  if (!no_verify)
+
+  (void)sig_s_len;
+  (void)sig_r_len;
+  (void)s_tmp;
+  (void)s_tmp2;
+  (void)p;
+  (void)i;
+
+
+  if (!no_verify) {
     if ((err = gcry_pk_hash_verify (s_sig, data_tmpl, s_pk, NULL, ctx))) {
-        #if !defined(HAVE_ED448)
+        #if defined(ENABLED_WOLFSSL_FIPS) && !defined(HAVE_ED448)
         if (strncmp(gpg_strerror(err), "Invalid object", 15) != 0) {
             fail("Should fail for ed448: %s", gpg_strerror(err));
         }
@@ -366,6 +375,7 @@ one_test (int testno, int ph, const char *sk, const char *pk,
               testno, gpg_strerror (err));
         #endif
     }
+  }
 
 
  leave:

--- a/tests/t-kdf.c
+++ b/tests/t-kdf.c
@@ -1413,6 +1413,7 @@ my_kdf_derive (int parallel,
   return err;
 }
 
+#if !defined(ENABLED_WOLFSSL_FIPS)
 static void
 check_argon2 (void)
 {
@@ -1554,7 +1555,7 @@ check_argon2 (void)
 #endif
     }
 }
-
+#endif
 
 static void
 check_balloon (void)


### PR DESCRIPTION
Cleaning up  a majority of the warnings related to the port show by the compiler.

Removing unused variables and functions, and turning off functions when not needed.