### PR TITLE
macro logic fix for sha512 fips on/off

### DIFF
--- a/cipher/mac-hmac.c
+++ b/cipher/mac-hmac.c
@@ -29,6 +29,10 @@
 #include "bufhelp.h"
 #include "cipher.h"
 
+#if defined(HAVE_WOLFSSL)
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
 
 static int
 map_mac_algo_to_md (int mac_algo)
@@ -1341,12 +1345,20 @@ const gcry_mac_spec_t _gcry_mac_type_spec_hmac_sha384 = {
 };
 
 const gcry_mac_spec_t _gcry_mac_type_spec_hmac_sha512_256 = {
+  #if !defined(HAVE_WOLFSSL) || !defined(WOLFSSL_NOSHA512_256)
   GCRY_MAC_HMAC_SHA512_256, {0, 1}, "HMAC_SHA512_256",
+  #else
+  GCRY_MAC_HMAC_SHA512_256, {0, 0}, "HMAC_SHA512_256",
+  #endif
   &hmac_ops
 };
 
 const gcry_mac_spec_t _gcry_mac_type_spec_hmac_sha512_224 = {
+  #if !defined(HAVE_WOLFSSL) || !defined(WOLFSSL_NOSHA512_224)
   GCRY_MAC_HMAC_SHA512_224, {0, 1}, "HMAC_SHA512_224",
+  #else
+  GCRY_MAC_HMAC_SHA512_224, {0, 0}, "HMAC_SHA512_224",
+  #endif
   &hmac_ops
 };
 

--- a/cipher/sha512.c
+++ b/cipher/sha512.c
@@ -1754,7 +1754,7 @@ static const gcry_md_oid_spec_t oid_spec_sha512_256[] =
 
 const gcry_md_spec_t _gcry_digest_spec_sha512_256 =
   {
-    #if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_NOSHA512_256)
+    #if !defined(HAVE_WOLFSSL) || !defined(WOLFSSL_NOSHA512_256)
     GCRY_MD_SHA512_256, {0, 1},
     #else
     GCRY_MD_SHA512_256, {0, 0}, /* Turn off FIPS mode for SHA512_256 */
@@ -1789,7 +1789,7 @@ static const gcry_md_oid_spec_t oid_spec_sha512_224[] =
 
 const gcry_md_spec_t _gcry_digest_spec_sha512_224 =
   {
-    #if !defined(HAVE_WOLFSSL) || defined(WOLFSSL_NOSHA512_224)
+    #if !defined(HAVE_WOLFSSL) || !defined(WOLFSSL_NOSHA512_224)
     GCRY_MD_SHA512_224, {0, 1},
     #else
     GCRY_MD_SHA512_224, {0, 0}, /* Turn off FIPS mode for SHA512_224 */


### PR DESCRIPTION
Typo issue involving turning sha512-224/256 on for fips