### PR TITLE
Use older gpg-error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ LIBGCRYPT_CONFIG_API_VERSION=1
 
 # If you change the required gpg-error version, please remove
 # unnecessary error code defines in src/gcrypt-int.h.
-NEED_GPG_ERROR_VERSION=1.49
+NEED_GPG_ERROR_VERSION=1.46
 
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_SRCDIR([src/libgcrypt.vers])

--- a/src/global.c
+++ b/src/global.c
@@ -326,7 +326,12 @@ print_config (const char *what, gpgrt_stream_t fp)
   if (!what || !strcmp (what, "cc"))
     {
       gpgrt_fprintf (fp, "cc:%d:%s:\n",
+
+#if GPGRT_VERSION_NUMBER >= 0x011b00 /* 1.27 */
                      GPGRT_GCC_VERSION,
+#else
+                     _GPG_ERR_GCC_VERSION, /* Due to a bug in gpg-error.h.  */
+#endif
 #ifdef __clang__
                      "clang:" __VERSION__
 #elif __GNUC__

--- a/src/misc.c
+++ b/src/misc.c
@@ -139,7 +139,13 @@ my_gpgrt_post_fatal_handler (int level)
 void
 _gcry_set_gpgrt_post_log_handler (void)
 {
+#if GPG_ERROR_VERSION_NUMBER >= 0x013100
   gpgrt_add_post_log_func (my_gpgrt_post_fatal_handler);
+#else
+# ifdef __GCC__
+  #warning Setting the post log handler requires gpgrt 1.49
+# endif
+#endif
 }
 
 
@@ -177,8 +183,7 @@ _gcry_logv (int level, const char *fmt, va_list arg_ptr)
     }
   else
     {
-      gpgrt_logv_domain ("gcrypt", map_log_level (level), NULL, NULL, 0,
-                         fmt, arg_ptr);
+      gpgrt_logv (map_log_level (level), fmt, arg_ptr);
     }
 }
 


### PR DESCRIPTION
Reverting commit f895a69 from upstream Gcrypt. This allows 1.46 libgpg-error to be used which is needed on Debian 12, so we no long need to pull in a newer version of GPG error