### PR TITLE
Fix when a library inits gcrypt then spins up multiple threads

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -104,6 +104,9 @@ global_init (void)
     if (wc_SetSeed_Cb(wc_GenerateSeed) != 0) {
       fprintf(stderr, "[WOLFSSL ERROR] wc_SetSeed_Cb failed\n");
     }
+    if (wc_RunAllCast_fips() != 0) {
+      fprintf(stderr, "[WOLFSSL ERROR] wc_RunAllCast_fips failed\n");
+    }
   }
 #endif
 


### PR DESCRIPTION
Without this wolfSSL will fail when threads are spun up after an init of gcrypt, but not reinit'd in the thread before usage. This fixes cast errors that occur.