### PR TITLE
rsa: verify PUBKEY_ENC_UNKNOWN via the raw compare path (fixes gpg/apt RSA verify)

### DIFF
--- a/cipher/rsa.c
+++ b/cipher/rsa.c
@@ -3612,6 +3612,7 @@ wc_rsa_verify (gcry_sexp_t s_sig, gcry_sexp_t s_data, gcry_sexp_t keyparms)
     case PUBKEY_ENC_PKCS1:
     case PUBKEY_ENC_RAW:
     case PUBKEY_ENC_OAEP:
+    case PUBKEY_ENC_UNKNOWN: /* GnuPG OpenPGP verify supplies the full encoded message and libgcrypt leaves encoding UNKNOWN; stock libgcrypt does the raw mpi_cmp for all non-PSS encodings, so handle it here instead of falling to default->BAD. */
       /* Allocate a buffer for the output */
       myDataLen = mySigLen;
 


### PR DESCRIPTION
Fixes #28.

`wc_rsa_verify()` rejected every RSA signature whose libgcrypt encoding context
is `PUBKEY_ENC_UNKNOWN`, because the `switch (ctx.encoding)` only handled the
named encodings (PSS / PKCS1 / PKCS1_RAW / RAW / OAEP) and routed everything else
to `default: rc = GPG_ERR_BAD_SIGNATURE`.

GnuPG's OpenPGP RSA verification supplies the full pre-encoded PKCS#1 v1.5
message and leaves `ctx.encoding == PUBKEY_ENC_UNKNOWN`, so **all** GnuPG/apt RSA
signature verification failed (keys "Unusable", "1 bad signature"). Stock
libgcrypt performs the raw `mpi_cmp(result, data)` for all non-PSS encodings;
this PR routes `PUBKEY_ENC_UNKNOWN` into the same `wc_RsaDirect` + `mpi_cmp`
group.

### Test

```sh
export GNUPGHOME=$(mktemp -d)
gpg --batch --pinentry-mode=loopback --passphrase "" \
    --quick-generate-key "test@example.com" rsa2048 sign 0
gpg --check-sigs
# before: "gpg: 1 bad signature"
# after:  clean
```

### Notes

- The crypto itself is correct: an OpenSSL-produced PKCS#1 v1.5 RSA-SHA256
  signature verifies through native wolfCrypt with the key loaded via
  `wc_RsaPublicKeyDecodeRaw` + `wc_RsaDirect(RSA_PUBLIC_DECRYPT)` (recovered EM is
  byte-for-byte correct). Only the shim's encoding dispatch was wrong.
- A more defensive alternative is to make the `default:` case perform the raw
  compare (matching stock libgcrypt) instead of adding an explicit case — happy
  to switch to that form if preferred.
