### PR TITLE
md: fix name/OID lookup for MD5 and post-shake digests (digest_list interior NULLs)

### DIFF
--- a/cipher/md.c
+++ b/cipher/md.c
@@ -109,11 +109,6 @@ static const gcry_md_spec_t * const digest_list[] =
      &_gcry_digest_spec_shake256,
      &_gcry_digest_spec_cshake128,
      &_gcry_digest_spec_cshake256,
-#else
-    NULL,
-    NULL,
-    NULL,
-    NULL,
 #endif
 #endif
 #if USE_GOST_R_3411_94


### PR DESCRIPTION
Fixes #30.

`digest_list[]` is a NULL-terminated scan array; under `HAVE_WOLFSSL` it had four
interior NULL placeholders (for the unavailable shake specs) that terminate
`spec_from_name()`/`spec_from_oid()` early, making MD5 and every post-shake
digest unresolvable by name/OID. `gcry_md_map_name("MD5")` returned 0, which
breaks GnuPG (aborts registering MD5 as a weak digest) and thus apt signature
verification.

This removes the interior NULLs so the array has no interior terminator. Under
`HAVE_WOLFSSL` the shake entries are simply absent. MD5 computation stays
refused by `NO_MD5` — only name/OID lookup is restored.

Verified: `gcry_md_map_name("MD5")` resolves again and `gpg --check-sigs` /
apt-key signature verification work.
